### PR TITLE
ver: update to v1.8.52

### DIFF
--- a/background.js
+++ b/background.js
@@ -44,8 +44,8 @@ let latestCurrentLanguage = null;    // 用于存储最新的 currentLanguage �
  * @param {string} domain - 域名
  * @returns {Promise<string|null>} 对应的语言代码或null
  */
-const getLanguageForDomain = async (domain) => {
-  return await domainRulesManager.getLanguageForDomain(domain);
+const getLanguageForDomain = (domain) => {
+  return domainRulesManager.getLanguageForDomain(domain);
 };
 
 
@@ -521,14 +521,14 @@ const handleUpdateCheckRequest = async (sendResponse) => {
   try {
     const repoOwner = 'ChuwuYo';
     const repoName = 'MultiLangSwitcher';
-    const currentVersion = '1.8.17'; // From manifest.json
+    const currentVersion = chrome.runtime.getManifest().version; // 动态获取manifest.json中的版本号
 
     sendBackgroundLog(backgroundI18n.t('update_check_initiated', { repo: `${repoOwner}/${repoName}` }), 'info');
 
-    // Create update checker instance
+    // 创建更新检查器实例
     const updateChecker = new UpdateChecker(repoOwner, repoName, currentVersion);
 
-    // Check cache status first
+    // 首先检查缓存状态
     const cacheStatus = updateChecker.getCacheStatus();
     if (cacheStatus.hasCachedData && !cacheStatus.isExpired) {
       sendBackgroundLog(backgroundI18n.t('update_check_cache_hit'), 'info');
@@ -538,10 +538,10 @@ const handleUpdateCheckRequest = async (sendResponse) => {
 
     sendBackgroundLog(backgroundI18n.t('update_check_api_request'), 'info');
 
-    // Perform update check
+    // 执行更新检查
     const updateInfo = await updateChecker.checkForUpdates();
 
-    // Log version comparison details
+    // 记录版本比较详情
     sendBackgroundLog(backgroundI18n.t('update_check_version_comparison', {
       current: updateInfo.currentVersion,
       latest: updateInfo.latestVersion,

--- a/background.js
+++ b/background.js
@@ -20,16 +20,16 @@ const DEFAULT_LANG_ZH = 'zh-CN'; // 为中文用户设置的默认语言
 const DEFAULT_LANG_EN = 'en';      // 为英文用户设置的默认语言，也用作自动切换的回退语言
 
 // 使用共享的sendDebugLog函数，但保留后台特定的日志前缀
-function sendBackgroundLog(message, logType = 'info') {
+const sendBackgroundLog = (message, logType = 'info') => {
   // 安全获取翻译，如果翻译系统未准备好则使用英文回退
-  const backgroundLabel = (backgroundI18n && backgroundI18n.isReady) 
-    ? backgroundI18n.t('background') 
+  const backgroundLabel = (backgroundI18n && backgroundI18n.isReady)
+    ? backgroundI18n.t('background')
     : 'Background';
-  
+
   // 确保同样的消息被用于控制台日志和调试日志
   console.log(`[${backgroundLabel} ${logType.toUpperCase()}] ${message}`);
   sendDebugLog(`[${backgroundLabel}] ${message}`, logType);
-}
+};
 
 // 全局状态变量
 let rulesCache = null;          // 规则缓存，避免重复获取已知规则
@@ -44,23 +44,23 @@ let latestCurrentLanguage = null;    // 用于存储最新的 currentLanguage �
  * @param {string} domain - 域名
  * @returns {Promise<string|null>} 对应的语言代码或null
  */
-async function getLanguageForDomain(domain) {
+const getLanguageForDomain = async (domain) => {
   return await domainRulesManager.getLanguageForDomain(domain);
-}
+};
 
 
 /**
  * 初始化域名规则管理器
  * @returns {Promise<void>}
  */
-async function initDomainRulesManager() {
+const initDomainRulesManager = async () => {
   try {
     await domainRulesManager.loadRules();
     sendBackgroundLog(backgroundI18n.t('domain_rules_loaded'), 'info');
   } catch (error) {
     sendBackgroundLog(`${backgroundI18n.t('domain_rules_load_failed')}: ${error.message}`, 'error');
   }
-}
+};
 
 // 在浏览器启动时初始化
 chrome.runtime.onStartup.addListener(() => {
@@ -78,12 +78,12 @@ const BASE_RETRY_DELAY = 500; // 毫秒
  * 清理所有动态规则
  * @returns {Promise<void>}
  */
-async function clearAllDynamicRules() {
+const clearAllDynamicRules = async () => {
   try {
     const existingRules = await chrome.declarativeNetRequest.getDynamicRules();
     if (existingRules.length > 0) {
       const ruleIds = existingRules.map(rule => rule.id);
-      sendBackgroundLog(backgroundI18n.t('clearing_existing_rules', {count: ruleIds.length}), 'info');
+      sendBackgroundLog(backgroundI18n.t('clearing_existing_rules', { count: ruleIds.length }), 'info');
       await chrome.declarativeNetRequest.updateDynamicRules({
         removeRuleIds: ruleIds
       });
@@ -102,16 +102,16 @@ async function clearAllDynamicRules() {
  * @param {boolean} isAutoSwitch - 是否由自动切换触发
  * @returns {Promise<Object>} 更新结果
  */
-async function updateHeaderRules(language, retryCount = 0, isAutoSwitch = false) {
+const updateHeaderRules = async (language, retryCount = 0, isAutoSwitch = false) => {
   language = language ? language.trim() : DEFAULT_LANG_EN;
-  
+
   // 检查是否需要更新（但对自动切换更宽松）
   if (!isAutoSwitch && language === lastAppliedLanguage && rulesCache) {
-    sendBackgroundLog(backgroundI18n.t('language_already_set', {language}), 'info');
+    sendBackgroundLog(backgroundI18n.t('language_already_set', { language }), 'info');
     return { status: 'cached', language };
   }
 
-  sendBackgroundLog(`${backgroundI18n.t('trying_update_rules', {language})}${retryCount > 0 ? ` (${backgroundI18n.t('retry')} #${retryCount})` : ''}`, 'info');
+  sendBackgroundLog(`${backgroundI18n.t('trying_update_rules', { language })}${retryCount > 0 ? ` (${backgroundI18n.t('retry')} #${retryCount})` : ''}`, 'info');
 
   try {
     // 获取现有规则
@@ -129,14 +129,14 @@ async function updateHeaderRules(language, retryCount = 0, isAutoSwitch = false)
     );
 
     if (existingRule) {
-      sendBackgroundLog(backgroundI18n.t('rules_already_set', {language}), 'info');
+      sendBackgroundLog(backgroundI18n.t('rules_already_set', { language }), 'info');
       lastAppliedLanguage = language;
       return { status: 'unchanged', language };
     }
 
     // 先清理所有现有规则，再添加新规则
     await clearAllDynamicRules();
-    
+
     // 添加新规则
     await chrome.declarativeNetRequest.updateDynamicRules({
       addRules: [{
@@ -161,9 +161,9 @@ async function updateHeaderRules(language, retryCount = 0, isAutoSwitch = false)
 
     // 规则更新成功
     lastAppliedLanguage = language;
-    sendBackgroundLog(`${backgroundI18n.t('rules_updated_successfully', {language})}${isAutoSwitch ? ` (${backgroundI18n.t('auto_switch')})` : ''}`, 'success');
+    sendBackgroundLog(`${backgroundI18n.t('rules_updated_successfully', { language })}${isAutoSwitch ? ` (${backgroundI18n.t('auto_switch')})` : ''}`, 'success');
     return { status: 'success', language };
-    
+
   } catch (error) {
     sendBackgroundLog(`${backgroundI18n.t('update_rules_failed')}: ${error.message}`, 'error');
     return handleRuleUpdateError(error, language, retryCount);
@@ -177,7 +177,7 @@ async function updateHeaderRules(language, retryCount = 0, isAutoSwitch = false)
  * @param {number} retryCount - 当前重试次数
  * @returns {Promise<Object>} 更新结果或抛出错误
  */
-async function handleRuleUpdateError(error, language, retryCount) {
+const handleRuleUpdateError = async (error, language, retryCount) => {
   // 对不同类型的错误进行分类处理
   let errorType = 'unknown';
   let canRetry = true;
@@ -200,14 +200,14 @@ async function handleRuleUpdateError(error, language, retryCount) {
     const nextRetryCount = retryCount + 1;
     const delay = BASE_RETRY_DELAY * Math.pow(2, retryCount);
 
-    sendBackgroundLog(`${backgroundI18n.t('retry_after', {delay, count: nextRetryCount})}`, 'warning');
+    sendBackgroundLog(`${backgroundI18n.t('retry_after', { delay, count: nextRetryCount })}`, 'warning');
 
     // 等待后重试
     await new Promise(resolve => setTimeout(resolve, delay));
     return await updateHeaderRules(language, nextRetryCount);
   } else {
     // 超过重试次数或不可重试的错误
-    const finalError = new Error(`${backgroundI18n.t('update_rules_failed_with_type', {type: errorType})}: ${error.message}`);
+    const finalError = new Error(`${backgroundI18n.t('update_rules_failed_with_type', { type: errorType })}: ${error.message}`);
     finalError.originalError = error;
     finalError.type = errorType;
     finalError.retryCount = retryCount;
@@ -222,7 +222,7 @@ async function handleRuleUpdateError(error, language, retryCount) {
         message: error.message,
         retryCount: retryCount
       }
-    }).catch(() => {});
+    }).catch(() => { });
 
     throw finalError;
   }
@@ -233,7 +233,7 @@ async function handleRuleUpdateError(error, language, retryCount) {
  * 统一的初始化函数，用于设置扩展的初始状态
  * @param {string} reason - 触发初始化的原因 (e.g., 'install', 'update', 'startup')
  */
-async function initializeState(reason) {
+const initializeState = async (reason) => {
   sendBackgroundLog(backgroundI18n.t('initializing_state', { reason }), 'info');
   try {
     // 1. 初始化域名规则管理器
@@ -304,7 +304,7 @@ chrome.runtime.onInstalled.addListener(details => {
  * @param {boolean} autoSwitchEnabled - 自动切换是否启用
  * @param {string} currentLanguage - 当前语言代码
  */
-function notifyPopupUIUpdate(autoSwitchEnabled, currentLanguage) {
+const notifyPopupUIUpdate = (autoSwitchEnabled, currentLanguage) => {
   // Store the latest state
   latestAutoSwitchEnabled = autoSwitchEnabled;
   latestCurrentLanguage = currentLanguage;
@@ -322,247 +322,319 @@ function notifyPopupUIUpdate(autoSwitchEnabled, currentLanguage) {
 }
 
 
-// 监听来自 popup 或 debug 页面的消息
-chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
-  if (request.type === 'UPDATE_RULES') {
-    (async () => {
-      try {
-        const language = request.language;
-        sendBackgroundLog(backgroundI18n.t('trying_update_rules', {language}), 'info');
-        
-        const result = await updateHeaderRules(language);
-        sendBackgroundLog(`${backgroundI18n.t('rules_update_completed')}: ${result.status}`, 'info');
-        
-        await chrome.storage.local.set({ currentLanguage: language });
-        
-        if (typeof sendResponse === 'function') {
-          sendResponse({ status: 'success', language: result.language });
-        }
-        
-        // 只在状态发生变化时才通知UI更新
-        if (result.status === 'success') {
-          notifyPopupUIUpdate(autoSwitchEnabled, result.language);
-        }
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        const errorType = error.type || 'UNKNOWN_ERROR';
-        
-        // 详细的错误日志，便于Debug页面查看
-        sendBackgroundLog(`${backgroundI18n.t('rules_update_failed')}: ${errorMessage} (${backgroundI18n.t('rule_update_error_type')}: ${errorType})`, 'error');
-        
-        // 如果有原始错误，也记录下来
-        if (error.originalError) {
-          sendBackgroundLog(`${backgroundI18n.t('original_error')}: ${error.originalError}`, 'error');
-        }
-        
-        if (typeof sendResponse === 'function') {
-          sendResponse({ 
-            status: 'error', 
-            message: errorMessage,
-            errorType: errorType
-          });
-        }
+/**
+ * 处理更新规则请求
+ * @param {Object} request - 请求对象
+ * @param {Function} sendResponse - 响应函数
+ */
+const handleUpdateRulesRequest = async (request, sendResponse) => {
+  try {
+    const language = request.language;
+    sendBackgroundLog(backgroundI18n.t('trying_update_rules', { language }), 'info');
+
+    const result = await updateHeaderRules(language);
+    sendBackgroundLog(`${backgroundI18n.t('rules_update_completed')}: ${result.status}`, 'info');
+
+    await chrome.storage.local.set({ currentLanguage: language });
+
+    if (typeof sendResponse === 'function') {
+      sendResponse({ status: 'success', language: result.language });
+    }
+
+    // 只在状态发生变化时才通知UI更新
+    if (result.status === 'success') {
+      notifyPopupUIUpdate(autoSwitchEnabled, result.language);
+    }
+  } catch (error) {
+    handleUpdateRulesError(error, sendResponse);
+  }
+};
+
+/**
+ * 处理更新规则错误
+ * @param {Error} error - 错误对象
+ * @param {Function} sendResponse - 响应函数
+ */
+const handleUpdateRulesError = (error, sendResponse) => {
+  const errorMessage = error instanceof Error ? error.message : String(error);
+  const errorType = error.type || 'UNKNOWN_ERROR';
+
+  // 详细的错误日志，便于Debug页面查看
+  sendBackgroundLog(`${backgroundI18n.t('rules_update_failed')}: ${errorMessage} (${backgroundI18n.t('rule_update_error_type')}: ${errorType})`, 'error');
+
+  // 如果有原始错误，也记录下来
+  if (error.originalError) {
+    sendBackgroundLog(`${backgroundI18n.t('original_error')}: ${error.originalError}`, 'error');
+  }
+
+  if (typeof sendResponse === 'function') {
+    sendResponse({
+      status: 'error',
+      message: errorMessage,
+      errorType: errorType
+    });
+  }
+};
+
+/**
+ * 处理自动切换开关请求
+ * @param {Object} request - 请求对象
+ * @param {Function} sendResponse - 响应函数
+ */
+const handleAutoSwitchToggleRequest = async (request, sendResponse) => {
+  try {
+    autoSwitchEnabled = request.enabled;
+    sendBackgroundLog(`${backgroundI18n.t('auto_switch_status_updated')}: ${autoSwitchEnabled}`, 'info');
+
+    await chrome.storage.local.set({ autoSwitchEnabled: autoSwitchEnabled });
+
+    // 广播状态变化给所有页面
+    chrome.runtime.sendMessage({
+      type: 'AUTO_SWITCH_STATE_CHANGED',
+      enabled: autoSwitchEnabled
+    }).catch(() => { });
+
+    if (autoSwitchEnabled) {
+      await handleAutoSwitchEnabled(sendResponse);
+    } else {
+      await handleAutoSwitchDisabled(sendResponse);
+    }
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    sendBackgroundLog(`${backgroundI18n.t('auto_switch_toggle_failed')}: ${errorMessage}`, 'error');
+    if (typeof sendResponse === 'function') {
+      sendResponse({ status: 'error', message: errorMessage });
+    }
+  }
+};
+
+/**
+ * 处理自动切换启用
+ * @param {Function} sendResponse - 响应函数
+ */
+const handleAutoSwitchEnabled = async (sendResponse) => {
+  sendBackgroundLog(backgroundI18n.t('auto_switch_enabled'), 'info');
+  await updateHeaderRules(DEFAULT_LANG_EN, 0, true);
+  if (typeof sendResponse === 'function') {
+    sendResponse({ status: 'success' });
+  }
+  notifyPopupUIUpdate(true, DEFAULT_LANG_EN);
+};
+
+/**
+ * 处理自动切换禁用
+ * @param {Function} sendResponse - 响应函数
+ */
+const handleAutoSwitchDisabled = async (sendResponse) => {
+  const result = await chrome.storage.local.get(['currentLanguage']);
+  const language = result.currentLanguage || DEFAULT_LANG_EN;
+  sendBackgroundLog(backgroundI18n.t('auto_switch_disabled', { language }), 'info');
+  await updateHeaderRules(language);
+  if (typeof sendResponse === 'function') {
+    sendResponse({ status: 'success' });
+  }
+  notifyPopupUIUpdate(false, language);
+};
+
+/**
+ * 处理获取当前语言请求
+ * @param {Function} sendResponse - 响应函数
+ */
+const handleGetCurrentLangRequest = async (sendResponse) => {
+  try {
+    const rules = await chrome.declarativeNetRequest.getDynamicRules();
+    const currentRule = rules.find(rule => rule.id === RULE_ID);
+    const actualCurrentLang = currentRule?.action?.requestHeaders?.find(h => h.header === 'Accept-Language')?.value;
+
+    const result = await chrome.storage.local.get(['currentLanguage', 'autoSwitchEnabled']);
+    if (typeof sendResponse === 'function') {
+      sendResponse({
+        currentLanguage: actualCurrentLang || result.currentLanguage || lastAppliedLanguage,
+        autoSwitchEnabled: !!result.autoSwitchEnabled
+      });
+    }
+  } catch (error) {
+    sendBackgroundLog(`${backgroundI18n.t('get_current_lang_error')}: ${error.message}`, 'error');
+    if (typeof sendResponse === 'function') {
+      sendResponse({ error: error.message });
+    }
+  }
+};
+
+/**
+ * 处理重置Accept-Language请求
+ * @param {Function} sendResponse - 响应函数
+ */
+const handleResetAcceptLanguageRequest = async (sendResponse) => {
+  try {
+    await chrome.declarativeNetRequest.updateDynamicRules({
+      removeRuleIds: [RULE_ID]
+    });
+
+    await chrome.storage.local.remove(['currentLanguage']);
+    lastAppliedLanguage = null;
+    sendBackgroundLog(backgroundI18n.t('accept_language_reset_successful'), 'success');
+    if (typeof sendResponse === 'function') {
+      sendResponse({ status: 'success' });
+    }
+    notifyPopupUIUpdate(autoSwitchEnabled, null);
+  } catch (error) {
+    sendBackgroundLog(`${backgroundI18n.t('reset_error')}: ${error.message}`, 'error');
+    if (typeof sendResponse === 'function') {
+      sendResponse({ status: 'error', message: error.message });
+    }
+  }
+};
+
+/**
+ * 处理获取域名规则请求
+ * @param {Function} sendResponse - 响应函数
+ */
+const handleGetDomainRulesRequest = async (sendResponse) => {
+  sendBackgroundLog(backgroundI18n.t('received_domain_rules_request'), 'info');
+
+  try {
+    await domainRulesManager.loadRules();
+    const rules = domainRulesManager.getRules();
+    const stats = domainRulesManager.getRulesStats();
+
+    sendBackgroundLog(backgroundI18n.t('domain_rules_fetch_success', { count: Object.keys(rules || {}).length }), 'success');
+
+    if (typeof sendResponse === 'function') {
+      sendResponse({ domainRules: rules, stats: stats });
+    }
+  } catch (error) {
+    const errorMessage = `${backgroundI18n.t('domain_rules_load_failed')}: ${error.message}`;
+    sendBackgroundLog(errorMessage, 'error');
+
+    if (typeof sendResponse === 'function') {
+      sendResponse({ error: errorMessage });
+    }
+  }
+};
+
+/**
+ * 处理更新检查请求
+ * @param {Function} sendResponse - 响应函数
+ */
+const handleUpdateCheckRequest = async (sendResponse) => {
+  try {
+    const repoOwner = 'ChuwuYo';
+    const repoName = 'MultiLangSwitcher';
+    const currentVersion = '1.8.17'; // From manifest.json
+
+    sendBackgroundLog(backgroundI18n.t('update_check_initiated', { repo: `${repoOwner}/${repoName}` }), 'info');
+
+    // Create update checker instance
+    const updateChecker = new UpdateChecker(repoOwner, repoName, currentVersion);
+
+    // Check cache status first
+    const cacheStatus = updateChecker.getCacheStatus();
+    if (cacheStatus.hasCachedData && !cacheStatus.isExpired) {
+      sendBackgroundLog(backgroundI18n.t('update_check_cache_hit'), 'info');
+    } else if (cacheStatus.hasCachedData && cacheStatus.isExpired) {
+      sendBackgroundLog(backgroundI18n.t('update_check_cache_expired'), 'info');
+    }
+
+    sendBackgroundLog(backgroundI18n.t('update_check_api_request'), 'info');
+
+    // Perform update check
+    const updateInfo = await updateChecker.checkForUpdates();
+
+    // Log version comparison details
+    sendBackgroundLog(backgroundI18n.t('update_check_version_comparison', {
+      current: updateInfo.currentVersion,
+      latest: updateInfo.latestVersion,
+      result: updateInfo.updateAvailable ? 'newer' : 'same_or_older'
+    }), 'info');
+
+    if (updateInfo.updateAvailable) {
+      sendBackgroundLog(backgroundI18n.t('update_check_update_available', {
+        current: updateInfo.currentVersion,
+        latest: updateInfo.latestVersion
+      }), 'success');
+    } else {
+      sendBackgroundLog(backgroundI18n.t('update_check_no_update_needed'), 'info');
+    }
+
+    sendBackgroundLog(backgroundI18n.t('update_check_success'), 'success');
+
+    if (typeof sendResponse === 'function') {
+      sendResponse({
+        status: 'success',
+        updateInfo: updateInfo
+      });
+    }
+
+  } catch (error) {
+    handleUpdateCheckError(error, sendResponse);
+  }
+};
+
+/**
+ * 处理更新检查错误
+ * @param {Error} error - 错误对象
+ * @param {Function} sendResponse - 响应函数
+ */
+const handleUpdateCheckError = (error, sendResponse) => {
+  const errorMessage = error instanceof Error ? error.message : String(error);
+
+  // Log specific error types with appropriate translations
+  if (error.type === 'TIMEOUT') {
+    sendBackgroundLog(backgroundI18n.t('update_check_timeout', { timeout: 10000 }), 'error');
+  } else if (error.type === 'NETWORK_ERROR') {
+    sendBackgroundLog(backgroundI18n.t('update_check_network_error', { error: errorMessage }), 'error');
+  } else if (error.type === 'RATE_LIMIT') {
+    sendBackgroundLog(backgroundI18n.t('update_check_rate_limited'), 'error');
+  } else if (error.type === 'INVALID_RESPONSE') {
+    sendBackgroundLog(backgroundI18n.t('update_check_invalid_response', { response: errorMessage }), 'error');
+  } else if (error.type === 'VERSION_ERROR') {
+    sendBackgroundLog(backgroundI18n.t('update_check_parsing_error', { error: errorMessage }), 'error');
+  } else {
+    sendBackgroundLog(backgroundI18n.t('update_check_failed', { error: errorMessage }), 'error');
+  }
+
+  if (typeof sendResponse === 'function') {
+    sendResponse({
+      status: 'error',
+      error: {
+        type: error.type || 'UNKNOWN_ERROR',
+        message: error.message || errorMessage,
+        userMessage: error.message || 'An unexpected error occurred',
+        retryable: error.retryable || false
       }
-    })();
+    });
+  }
+};
+
+// 监听来自 popup 或 debug 页面的消息
+chrome.runtime.onMessage.addListener((request, _, sendResponse) => {
+  if (request.type === 'UPDATE_RULES') {
+    handleUpdateRulesRequest(request, sendResponse);
     return true;
   } else if (request.type === 'AUTO_SWITCH_TOGGLED') {
-    (async () => {
-      try {
-        autoSwitchEnabled = request.enabled;
-        sendBackgroundLog(`${backgroundI18n.t('auto_switch_status_updated')}: ${autoSwitchEnabled}`, 'info');
-        
-        await chrome.storage.local.set({ autoSwitchEnabled: autoSwitchEnabled });
-
-        // 广播状态变化给所有页面
-        chrome.runtime.sendMessage({
-          type: 'AUTO_SWITCH_STATE_CHANGED',
-          enabled: autoSwitchEnabled
-        }).catch(() => {});
-
-        if (autoSwitchEnabled) {
-          sendBackgroundLog(backgroundI18n.t('auto_switch_enabled'), 'info');
-          const result = await updateHeaderRules(DEFAULT_LANG_EN, 0, true);
-          if (typeof sendResponse === 'function') {
-            sendResponse({ status: 'success' });
-          }
-          notifyPopupUIUpdate(true, DEFAULT_LANG_EN);
-        } else {
-          const result = await chrome.storage.local.get(['currentLanguage']);
-          const language = result.currentLanguage || DEFAULT_LANG_EN;
-          sendBackgroundLog(backgroundI18n.t('auto_switch_disabled', {language}), 'info');
-          await updateHeaderRules(language);
-          if (typeof sendResponse === 'function') {
-            sendResponse({ status: 'success' });
-          }
-          notifyPopupUIUpdate(false, language);
-        }
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        sendBackgroundLog(`${backgroundI18n.t('auto_switch_toggle_failed')}: ${errorMessage}`, 'error');
-        if (typeof sendResponse === 'function') {
-          sendResponse({ status: 'error', message: errorMessage });
-        }
-      }
-    })();
+    handleAutoSwitchToggleRequest(request, sendResponse);
     return true;
   } else if (request.type === 'GET_CURRENT_LANG') {
-    (async () => {
-      try {
-        const rules = await chrome.declarativeNetRequest.getDynamicRules();
-        const currentRule = rules.find(rule => rule.id === RULE_ID);
-        const actualCurrentLang = currentRule?.action?.requestHeaders?.find(h => h.header === 'Accept-Language')?.value;
-        
-        const result = await chrome.storage.local.get(['currentLanguage', 'autoSwitchEnabled']);
-        if (typeof sendResponse === 'function') {
-          sendResponse({
-            currentLanguage: actualCurrentLang || result.currentLanguage || lastAppliedLanguage,
-            autoSwitchEnabled: !!result.autoSwitchEnabled
-          });
-        }
-      } catch (error) {
-        sendBackgroundLog(`${backgroundI18n.t('get_current_lang_error')}: ${error.message}`, 'error');
-        if (typeof sendResponse === 'function') {
-          sendResponse({ error: error.message });
-        }
-      }
-    })();
+    handleGetCurrentLangRequest(sendResponse);
     return true;
   } else if (request.type === 'RESET_ACCEPT_LANGUAGE') {
-    (async () => {
-      try {
-        await chrome.declarativeNetRequest.updateDynamicRules({
-          removeRuleIds: [RULE_ID]
-        });
-        
-        await chrome.storage.local.remove(['currentLanguage']);
-        lastAppliedLanguage = null;
-        sendBackgroundLog(backgroundI18n.t('accept_language_reset_successful'), 'success');
-        if (typeof sendResponse === 'function') {
-          sendResponse({ status: 'success' });
-        }
-        notifyPopupUIUpdate(autoSwitchEnabled, null);
-      } catch (error) {
-        sendBackgroundLog(`${backgroundI18n.t('reset_error')}: ${error.message}`, 'error');
-        if (typeof sendResponse === 'function') {
-          sendResponse({ status: 'error', message: error.message });
-        }
-      }
-    })();
+    handleResetAcceptLanguageRequest(sendResponse);
     return true;
   } else if (request.type === 'GET_DOMAIN_RULES') {
-    sendBackgroundLog(backgroundI18n.t('received_domain_rules_request'), 'info');
-    try {
-      // 确保规则已加载
-      domainRulesManager.loadRules().then(() => {
-        const rules = domainRulesManager.getRules();
-        const stats = domainRulesManager.getRulesStats();
-        sendBackgroundLog(backgroundI18n.t('domain_rules_fetch_success', {count: Object.keys(rules || {}).length}), 'success');
-        if (typeof sendResponse === 'function') {
-          sendResponse({ domainRules: rules, stats: stats });
-        }
-      }).catch(error => {
-        sendBackgroundLog(`${backgroundI18n.t('domain_rules_load_failed')}: ${error.message}`, 'error');
-        if (typeof sendResponse === 'function') {
-          sendResponse({ error: `${backgroundI18n.t('domain_rules_load_failed')}: ${error.message}` });
-        }
-      });
-    } catch (e) {
-      sendBackgroundLog(`${backgroundI18n.t('process_get_domain_rules_error')}: ${e.message}`, 'error');
-      if (typeof sendResponse === 'function') {
-        sendResponse({ error: `${backgroundI18n.t('process_get_domain_rules_error')}: ${e.message}` });
-      }
-    }
+    handleGetDomainRulesRequest(sendResponse);
     return true;
   } else if (request.type === 'UPDATE_CHECK') {
-    (async () => {
-      try {
-        const repoOwner = 'ChuwuYo';
-        const repoName = 'MultiLangSwitcher';
-        const currentVersion = '1.8.17'; // From manifest.json
-        
-        sendBackgroundLog(backgroundI18n.t('update_check_initiated', {repo: `${repoOwner}/${repoName}`}), 'info');
-        
-        // Create update checker instance
-        const updateChecker = new UpdateChecker(repoOwner, repoName, currentVersion);
-        
-        // Check cache status first
-        const cacheStatus = updateChecker.getCacheStatus();
-        if (cacheStatus.hasCachedData && !cacheStatus.isExpired) {
-          sendBackgroundLog(backgroundI18n.t('update_check_cache_hit'), 'info');
-        } else if (cacheStatus.hasCachedData && cacheStatus.isExpired) {
-          sendBackgroundLog(backgroundI18n.t('update_check_cache_expired'), 'info');
-        }
-        
-        sendBackgroundLog(backgroundI18n.t('update_check_api_request'), 'info');
-        
-        // Perform update check
-        const updateInfo = await updateChecker.checkForUpdates();
-        
-        // Log version comparison details
-        sendBackgroundLog(backgroundI18n.t('update_check_version_comparison', {
-          current: updateInfo.currentVersion,
-          latest: updateInfo.latestVersion,
-          result: updateInfo.updateAvailable ? 'newer' : 'same_or_older'
-        }), 'info');
-        
-        if (updateInfo.updateAvailable) {
-          sendBackgroundLog(backgroundI18n.t('update_check_update_available', {
-            current: updateInfo.currentVersion,
-            latest: updateInfo.latestVersion
-          }), 'success');
-        } else {
-          sendBackgroundLog(backgroundI18n.t('update_check_no_update_needed'), 'info');
-        }
-        
-        sendBackgroundLog(backgroundI18n.t('update_check_success'), 'success');
-        
-        if (typeof sendResponse === 'function') {
-          sendResponse({
-            status: 'success',
-            updateInfo: updateInfo
-          });
-        }
-        
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        
-        // Log specific error types with appropriate translations
-        if (error.type === 'TIMEOUT') {
-          sendBackgroundLog(backgroundI18n.t('update_check_timeout', {timeout: 10000}), 'error');
-        } else if (error.type === 'NETWORK_ERROR') {
-          sendBackgroundLog(backgroundI18n.t('update_check_network_error', {error: errorMessage}), 'error');
-        } else if (error.type === 'RATE_LIMIT') {
-          sendBackgroundLog(backgroundI18n.t('update_check_rate_limited'), 'error');
-        } else if (error.type === 'INVALID_RESPONSE') {
-          sendBackgroundLog(backgroundI18n.t('update_check_invalid_response', {response: errorMessage}), 'error');
-        } else if (error.type === 'VERSION_ERROR') {
-          sendBackgroundLog(backgroundI18n.t('update_check_parsing_error', {error: errorMessage}), 'error');
-        } else {
-          sendBackgroundLog(backgroundI18n.t('update_check_failed', {error: errorMessage}), 'error');
-        }
-        
-        if (typeof sendResponse === 'function') {
-          sendResponse({
-            status: 'error',
-            error: {
-              type: error.type || 'UNKNOWN_ERROR',
-              message: error.message || errorMessage,
-              userMessage: error.message || 'An unexpected error occurred',
-              retryable: error.retryable || false
-            }
-          });
-        }
-      }
-    })();
+    handleUpdateCheckRequest(sendResponse);
     return true;
   }
 });
 
 // 监听标签页更新以实现自动切换 (Manifest V3 compatible)
-chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
+chrome.tabs.onUpdated.addListener(async (_, changeInfo, tab) => {
   // 调试日志：记录所有相关事件
   if (changeInfo.status === 'complete' && tab?.url?.startsWith('http')) {
-    sendBackgroundLog(backgroundI18n.t('tab_update_debug', {url: tab.url, autoSwitch: autoSwitchEnabled}), 'info');
+    sendBackgroundLog(backgroundI18n.t('tab_update_debug', { url: tab.url, autoSwitch: autoSwitchEnabled }), 'info');
   }
 
   // 确保自动切换已启用，标签页加载完成，并且有有效的URL (http or https)
@@ -574,28 +646,28 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
       let targetLanguage = null;
 
       // 使用域名规则管理器获取语言
-      sendBackgroundLog(backgroundI18n.t('finding_language_rule', {hostname: currentHostname}), 'info');
+      sendBackgroundLog(backgroundI18n.t('finding_language_rule', { hostname: currentHostname }), 'info');
       targetLanguage = await getLanguageForDomain(currentHostname);
       if (targetLanguage) {
-        sendBackgroundLog(backgroundI18n.t('domain_rule_match_success', {hostname: currentHostname, language: targetLanguage}), 'success');
+        sendBackgroundLog(backgroundI18n.t('domain_rule_match_success', { hostname: currentHostname, language: targetLanguage }), 'success');
       }
 
       if (targetLanguage) {
-        sendBackgroundLog(backgroundI18n.t('auto_switching_hostname', {hostname: currentHostname, language: targetLanguage}), 'info');
+        sendBackgroundLog(backgroundI18n.t('auto_switching_hostname', { hostname: currentHostname, language: targetLanguage }), 'info');
         // 调用 updateHeaderRules 更新请求头，标记为自动切换 (isAutoSwitch = true)
         try {
           const result = await updateHeaderRules(targetLanguage, 0, true);
-          sendBackgroundLog(backgroundI18n.t('auto_switch_success', {hostname: currentHostname, language: targetLanguage, status: result.status}), 'success');
+          sendBackgroundLog(backgroundI18n.t('auto_switch_success', { hostname: currentHostname, language: targetLanguage, status: result.status }), 'success');
           if (result.status === 'success') {
             notifyPopupUIUpdate(true, targetLanguage);
           }
         } catch (error) {
-          sendBackgroundLog(`${backgroundI18n.t('auto_switch_failed', {hostname: currentHostname, language: targetLanguage})}: ${error.message}`, 'error');
+          sendBackgroundLog(`${backgroundI18n.t('auto_switch_failed', { hostname: currentHostname, language: targetLanguage })}: ${error.message}`, 'error');
         }
       } else {
         // 如果没有匹配的规则，使用回退语言
         const fallbackLanguage = DEFAULT_LANG_EN;
-        sendBackgroundLog(backgroundI18n.t('no_matching_rule', {hostname: currentHostname, fallback: fallbackLanguage}), 'info');
+        sendBackgroundLog(backgroundI18n.t('no_matching_rule', { hostname: currentHostname, fallback: fallbackLanguage }), 'info');
         // 只有在当前语言不是回退语言时才更新
         try {
           const rules = await chrome.declarativeNetRequest.getDynamicRules();
@@ -604,20 +676,20 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
 
           if (currentLang !== fallbackLanguage) {
             const result = await updateHeaderRules(fallbackLanguage, 0, true);
-            sendBackgroundLog(backgroundI18n.t('fallback_language_applied', {hostname: currentHostname, fallback: fallbackLanguage, status: result.status}), 'info');
+            sendBackgroundLog(backgroundI18n.t('fallback_language_applied', { hostname: currentHostname, fallback: fallbackLanguage, status: result.status }), 'info');
             if (result.status === 'success') {
               notifyPopupUIUpdate(true, fallbackLanguage);
             }
           } else {
-            sendBackgroundLog(backgroundI18n.t('current_is_fallback', {fallback: fallbackLanguage}), 'info');
+            sendBackgroundLog(backgroundI18n.t('current_is_fallback', { fallback: fallbackLanguage }), 'info');
           }
         } catch (error) {
-          sendBackgroundLog(`${backgroundI18n.t('fallback_language_failed', {hostname: currentHostname})}: ${error.message}`, 'error');
+          sendBackgroundLog(`${backgroundI18n.t('fallback_language_failed', { hostname: currentHostname })}: ${error.message}`, 'error');
         }
       }
     } catch (e) {
       // 捕获并记录解析URL或处理过程中可能发生的任何错误
-      sendBackgroundLog(`${backgroundI18n.t('error_processing_url', {url: tab.url})}: ${e.message}`, 'error');
+      sendBackgroundLog(`${backgroundI18n.t('error_processing_url', { url: tab.url })}: ${e.message}`, 'error');
     }
   }
 });

--- a/debug-headers.js
+++ b/debug-headers.js
@@ -5,10 +5,10 @@
 /**
  * 显示当前生效的动态规则和最近匹配的规则
  */
-async function showCurrentRules() {
+const showCurrentRules = async () => {
   try {
     sendDebugLog(debugI18n.t('getting_rules'), 'info');
-    
+
     const rules = await chrome.declarativeNetRequest.getDynamicRules();
     sendDebugLog(`${debugI18n.t('current_rules')} ${JSON.stringify(rules, null, 2)}`, 'info');
 
@@ -19,17 +19,17 @@ async function showCurrentRules() {
 
     const matchedRules = await chrome.declarativeNetRequest.getMatchedRules({});
     sendDebugLog(`${debugI18n.t('matched_rules')} ${JSON.stringify(matchedRules, null, 2)}`, 'info');
-    
+
   } catch (error) {
-    sendDebugLog(`${debugI18n.t('get_rules_error')}${error.message}`, 'error');
+    sendDebugLog(`${debugI18n.t('get_rules_error')} ${error.message}`, 'error');
   }
-}
+};
 
 /**
  * 测试指定语言的 Accept-Language 请求头是否生效
  * @param {string} language - 要测试的语言代码
  */
-async function testHeaderChange(language) {
+const testHeaderChange = async (language) => {
   if (!language) {
     sendDebugLog(debugI18n.t('invalid_language_code'), 'error');
     return;
@@ -39,21 +39,21 @@ async function testHeaderChange(language) {
     sendDebugLog(`${debugI18n.t('testing_language')} "${language}" ${debugI18n.t('header_effective')}`, 'info');
 
     const timestamp = Date.now();
-    const data = await fetchWithRetry(`https://httpbin.org/headers?_=${timestamp}`, { 
-      cache: 'no-store', 
-      credentials: 'omit' 
+    const data = await fetchWithRetry(`https://httpbin.org/headers?_=${timestamp}`, {
+      cache: 'no-store',
+      credentials: 'omit'
     });
-    
+
     handleHeaderResponse(data, language);
-    
+
   } catch (error) {
     sendDebugLog(`${debugI18n.t('test_failed')} ${error.message}`, 'error');
-    
+
     if (error.message.includes('Failed to fetch')) {
       sendDebugLog(debugI18n.t('network_check_suggestion'), 'info');
     }
   }
-}
+};
 
 /**
  * 带重试机制的fetch请求
@@ -61,22 +61,22 @@ async function testHeaderChange(language) {
  * @param {Object} options - fetch选项
  * @returns {Promise<Object>} 响应数据
  */
-async function fetchWithRetry(url, options = {}) {
+const fetchWithRetry = async (url, options = {}) => {
   const response = await fetch(url, options);
-  
+
   if (!response.ok) {
     throw new Error(`${debugI18n.t('http_error_status')} ${response.status}`);
   }
-  
+
   return response.json();
-}
+};
 
 /**
  * 处理获取到的请求头数据
  * @param {Object} data - 从API返回的数据
  * @param {string} language - 预期的语言代码
  */
-function handleHeaderResponse(data, language) {
+const handleHeaderResponse = (data, language) => {
   const headers = data.headers;
   sendDebugLog(`${debugI18n.t('received_headers')} ${JSON.stringify(headers, null, 2)}`, 'info');
 
@@ -93,7 +93,7 @@ function handleHeaderResponse(data, language) {
   } else {
     sendDebugLog(`${debugI18n.t('header_not_changed')} ${expectedLanguage}, ${debugI18n.t('actually_detected')} ${acceptLanguage}`, 'error');
   }
-}
+};
 
 // 导出函数供控制台使用
 window.debugHeaders = {

--- a/debug-ui.js
+++ b/debug-ui.js
@@ -56,7 +56,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }
 
       // 获取最近匹配的规则信息
-      chrome.declarativeNetRequest.getMatchedRules({}, function (matchedRules) {
+      chrome.declarativeNetRequest.getMatchedRules({}, (matchedRules) => {
         html += `<h5>${debugI18n.t('recent_matched_rules')}</h5>`;
         if (matchedRules && matchedRules.rulesMatchedInfo && matchedRules.rulesMatchedInfo.length > 0) {
           html += '<ul>';
@@ -103,17 +103,17 @@ document.addEventListener('DOMContentLoaded', () => {
    * @param {string} message - 日志消息内容
    * @param {string} logType - 日志类型 (info, warning, error, success)
    */
-  function addLogMessage(message, logType = 'info') {
+  const addLogMessage = (message, logType = 'info') => {
     const timestamp = new Date().toLocaleTimeString();
     const logEntry = { timestamp, message, logType };
     allLogMessages.push(logEntry);
     renderLogs(); // 重新渲染日志以应用过滤
     // 自动滚动到底部
     logOutput.scrollTop = logOutput.scrollHeight;
-  }
+  };
 
   // 根据当前过滤器渲染日志
-  function renderLogs() {
+  const renderLogs = () => {
     logOutput.innerHTML = ''; // 清空当前显示
     const activeFilters = getActiveFilters();
 
@@ -125,21 +125,21 @@ document.addEventListener('DOMContentLoaded', () => {
         logOutput.appendChild(logElement);
       }
     });
-  }
+  };
 
 
   /**
    * 获取当前选中的日志类型过滤器
    * @returns {string[]} - 激活的日志类型数组
    */
-  function getActiveFilters() {
+  const getActiveFilters = () => {
     const filters = [];
     if (document.getElementById('filterInfo').checked) filters.push('info');
     if (document.getElementById('filterWarning').checked) filters.push('warning');
     if (document.getElementById('filterError').checked) filters.push('error');
     if (document.getElementById('filterSuccess').checked) filters.push('success');
     return filters;
-  }
+  };
 
   // 监听来自扩展其他部分的日志消息
   chrome.runtime.onMessage.addListener((request) => {
@@ -281,7 +281,7 @@ document.addEventListener('DOMContentLoaded', () => {
     resultElement.innerHTML = debugI18n.t('fixing_rule_priority');
     addLogMessage(debugI18n.t('try_fix_priority'), 'info');
 
-    chrome.declarativeNetRequest.getDynamicRules(function (existingRules) {
+    chrome.declarativeNetRequest.getDynamicRules((existingRules) => {
       const existingRuleIds = existingRules.map(rule => rule.id);
       const updatedRules = existingRules.map(rule => {
         return {
@@ -293,7 +293,7 @@ document.addEventListener('DOMContentLoaded', () => {
       chrome.declarativeNetRequest.updateDynamicRules({
         removeRuleIds: existingRuleIds,
         addRules: updatedRules
-      }, function () {
+      }, () => {
         if (chrome.runtime.lastError) {
           resultElement.innerHTML = `<p class="error">${debugI18n.t('fix_failed')} ${chrome.runtime.lastError.message}</p>`;
           addLogMessage(`${debugI18n.t('fix_priority_failed')} ${chrome.runtime.lastError.message}`, 'error');
@@ -311,21 +311,21 @@ document.addEventListener('DOMContentLoaded', () => {
     resultElement.innerHTML = debugI18n.t('clearing_rules_reapply');
     addLogMessage(debugI18n.t('try_clear_reapply'), 'info');
 
-    chrome.declarativeNetRequest.getDynamicRules(function (existingRules) {
+    chrome.declarativeNetRequest.getDynamicRules((existingRules) => {
       const existingRuleIds = existingRules.map(rule => rule.id);
 
       chrome.declarativeNetRequest.updateDynamicRules({
         removeRuleIds: existingRuleIds
-      }, function () {
+      }, () => {
         if (chrome.runtime.lastError) {
           resultElement.innerHTML = `<p class="error">${debugI18n.t('clear_failed')} ${chrome.runtime.lastError.message}</p>`;
           addLogMessage(`${debugI18n.t('clear_rules_failed')} ${chrome.runtime.lastError.message}`, 'error');
         } else {
           // 清除成功后，重新应用默认或存储的规则
-          chrome.storage.local.get(['currentLanguage'], function (result) {
+          chrome.storage.local.get(['currentLanguage'], (result) => {
             const languageToApply = result.currentLanguage || 'zh-CN';
             // Send message to background.js to request rule update
-            chrome.runtime.sendMessage({ type: 'UPDATE_RULES', language: languageToApply }, function (response) {
+            chrome.runtime.sendMessage({ type: 'UPDATE_RULES', language: languageToApply }, (response) => {
               if (chrome.runtime.lastError) {
                 resultElement.innerHTML = `<p class="error">${debugI18n.t('reapply_rules_error')} ${chrome.runtime.lastError.message}</p>`;
                 addLogMessage(`${debugI18n.t('request_background_reapply_failed')} ${chrome.runtime.lastError.message}`, 'error');
@@ -351,7 +351,7 @@ document.addEventListener('DOMContentLoaded', () => {
    * @param {string} languageString - 要验证的语言字符串
    * @returns {boolean} - 如果格式可能有问题返回 true
    */
-  function validateAcceptLanguageFormat(languageString) {
+  const validateAcceptLanguageFormat = (languageString) => {
     // 基本格式检查
     const trimmed = languageString.trim();
 
@@ -429,7 +429,7 @@ document.addEventListener('DOMContentLoaded', () => {
     addLogMessage(`${debugI18n.t('try_apply_custom')} ${languageString}`, 'info');
 
     // 发送消息到 background.js 请求更新规则
-    chrome.runtime.sendMessage({ type: 'UPDATE_RULES', language: languageString }, function (response) {
+    chrome.runtime.sendMessage({ type: 'UPDATE_RULES', language: languageString }, (response) => {
       if (chrome.runtime.lastError) {
         customLangResult.innerHTML = `<p class="error">${debugI18n.t('apply_custom_failed')} ${chrome.runtime.lastError.message}</p>`;
         addLogMessage(`${debugI18n.t('apply_custom_failed')} ${chrome.runtime.lastError.message}`, 'error');
@@ -529,7 +529,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }
 
       // 获取存储的语言设置和自动切换状态 (移入 try 块，确保在 manifest 读取成功后执行)
-      chrome.storage.local.get(['currentLanguage', 'autoSwitchEnabled'], function (result) {
+      chrome.storage.local.get(['currentLanguage', 'autoSwitchEnabled'], (result) => {
         try {
           if (chrome.runtime.lastError) {
             throw new Error(`${debugI18n.t('storage_failed')} ${chrome.runtime.lastError.message}`);
@@ -595,13 +595,13 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   // 显示域名映射规则
-  document.getElementById('showDomainRulesBtn').addEventListener('click', function () {
+  document.getElementById('showDomainRulesBtn').addEventListener('click', () => {
     const resultElement = document.getElementById('domainRulesResult');
     resultElement.innerHTML = debugI18n.t('getting_domain_rules');
     addLogMessage(debugI18n.t('try_get_domain_rules'), 'info');
 
     // 从 background.js 获取域名映射规则
-    chrome.runtime.sendMessage({ type: 'GET_DOMAIN_RULES' }, function (response) {
+    chrome.runtime.sendMessage({ type: 'GET_DOMAIN_RULES' }, (response) => {
       if (chrome.runtime.lastError) {
         resultElement.innerHTML = `<p class="error">${debugI18n.t('get_domain_rules_failed')} ${chrome.runtime.lastError.message}</p>`;
         addLogMessage(`${debugI18n.t('get_domain_rules_failed')} ${chrome.runtime.lastError.message}`, 'error');

--- a/detect.js
+++ b/detect.js
@@ -205,7 +205,7 @@ function md5(string) {
  * 获取浏览器信息
  * @returns {Object} 浏览器信息对象
  */
-function getBrowserInfo() {
+const getBrowserInfo = () => {
   const ua = navigator.userAgent;
   let browserName = detectI18n.t('unknown_browser');
   let browserVersion = detectI18n.t('unknown_version');
@@ -267,7 +267,7 @@ function getBrowserInfo() {
  * 检查API支持情况
  * @returns {Array} API支持情况列表
  */
-function checkApiSupport() {
+const checkApiSupport = () => {
   const apis = [
     { name: 'localStorage', supported: typeof localStorage !== 'undefined' },
     { name: 'sessionStorage', supported: typeof sessionStorage !== 'undefined' },
@@ -295,7 +295,7 @@ function checkApiSupport() {
 /**
  * 执行浏览器兼容性检查
  */
-function performCompatibilityChecks() {
+const performCompatibilityChecks = () => {
   const browserInfoEl = document.getElementById('browserInfoDisplay');
   const apiListEl = document.getElementById('apiCompatibilityList');
   if (!browserInfoEl || !apiListEl) return;
@@ -327,7 +327,7 @@ function performCompatibilityChecks() {
  * 获取并显示当前请求头
  * @returns {Promise<void>}
  */
-async function fetchAndDisplayHeaders() {
+const fetchAndDisplayHeaders = async () => {
   const headerInfoElement = document.getElementById('headerInfo');
   const headerLanguageInfo = document.getElementById('headerLanguageInfo');
   if (!headerInfoElement || !headerLanguageInfo) return;
@@ -359,7 +359,7 @@ async function fetchAndDisplayHeaders() {
  * @param {number} timeoutMs - 超时时间（毫秒）
  * @returns {Promise<Object>} - 解析为第一个成功的响应数据
  */
-async function fetchFromAnySource(urls, timeoutMs) {
+const fetchFromAnySource = async (urls, timeoutMs) => {
   const promises = urls.map(url => fetchWithTimeout(url, timeoutMs));
   return await Promise.any(promises);
 }
@@ -370,7 +370,7 @@ async function fetchFromAnySource(urls, timeoutMs) {
  * @param {number} timeoutMs - 超时时间（毫秒）
  * @returns {Promise<Object>} - 解析为响应数据
  */
-async function fetchWithTimeout(url, timeoutMs) {
+const fetchWithTimeout = async (url, timeoutMs) => {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
@@ -405,7 +405,7 @@ async function fetchWithTimeout(url, timeoutMs) {
  * @param {HTMLElement} headerInfoElement - 显示请求头信息的元素
  * @param {HTMLElement} headerLanguageInfo - 显示语言信息的元素
  */
-function processHeadersData(data, headerInfoElement, headerLanguageInfo) {
+const processHeadersData = (data, headerInfoElement, headerLanguageInfo) => {
   const headers = data.headers;
   const formattedHeaders = JSON.stringify(headers, null, 2);
   headerInfoElement.textContent = formattedHeaders;
@@ -439,7 +439,7 @@ function processHeadersData(data, headerInfoElement, headerLanguageInfo) {
  * @param {HTMLElement} headerInfoElement - 显示请求头信息的元素
  * @param {HTMLElement} headerLanguageInfo - 显示语言信息的元素
  */
-function handleHeaderFetchError(error, headerInfoElement, headerLanguageInfo) {
+const handleHeaderFetchError = (error, headerInfoElement, headerLanguageInfo) => {
   let combinedErrorMessage = detectI18n.t('fetch_failed_all_services');
   
   if (error instanceof AggregateError) {
@@ -457,7 +457,7 @@ function handleHeaderFetchError(error, headerInfoElement, headerLanguageInfo) {
 /**
  * 检测 JavaScript 语言偏好
  */
-function detectJsLanguage() {
+const detectJsLanguage = () => {
   const jsLanguageInfoElement = document.getElementById('jsLanguageInfo');
   if (!jsLanguageInfoElement) return;
   
@@ -481,7 +481,7 @@ function detectJsLanguage() {
 /**
  * 检测 Canvas 指纹
  */
-function detectCanvasFingerprint() {
+const detectCanvasFingerprint = () => {
   const canvasInfoElement = document.getElementById('canvasFingerprintInfo');
   if (!canvasInfoElement) return;
   
@@ -517,7 +517,7 @@ function detectCanvasFingerprint() {
 /**
  * 检测 WebGL 指纹
  */
-function detectWebglFingerprint() {
+const detectWebglFingerprint = () => {
   const webglInfoElement = document.getElementById('webglFingerprintInfo');
   if (!webglInfoElement) return;
   
@@ -564,7 +564,7 @@ function detectWebglFingerprint() {
  * 检测 AudioContext 指纹
  * @returns {Promise<void>}
  */
-async function detectAudioFingerprint() {
+const detectAudioFingerprint = async () => {
   const audioInfoElement = document.getElementById('audioFingerprintInfo');
   if (!audioInfoElement) return;
   
@@ -620,7 +620,7 @@ async function detectAudioFingerprint() {
 /**
  * 检测国际化 API
  */
-function detectIntlApi() {
+const detectIntlApi = () => {
   const intlApiInfoElement = document.getElementById('intlApiInfo');
   if (!intlApiInfoElement) return;
   
@@ -644,7 +644,7 @@ function detectIntlApi() {
 /**
  * 检测 WebRTC IP 泄露
  */
-async function detectWebRtc() {
+const detectWebRtc = async () => {
   const webRtcInfoElement = document.getElementById('webRtcInfo');
   if (!webRtcInfoElement) return;
   
@@ -677,7 +677,7 @@ async function detectWebRtc() {
  * 收集WebRTC IP地址
  * @returns {Promise<Array<string>>} IP地址列表
  */
-async function collectWebRtcIps() {
+const collectWebRtcIps = async () => {
   return new Promise((resolve) => {
     const ips = [];
     
@@ -714,7 +714,7 @@ async function collectWebRtcIps() {
 /**
  * 检测部分浏览器指纹信息
  */
-function detectFingerprint() {
+const detectFingerprint = () => {
   const fingerprintInfoElement = document.getElementById('fingerprintInfo');
   if (!fingerprintInfoElement) return;
   
@@ -743,7 +743,7 @@ function detectFingerprint() {
 /**
  * 添加刷新按钮
  */
-function addRefreshButton() {
+const addRefreshButton = () => {
   const refreshButton = document.createElement('button');
   refreshButton.className = 'btn btn-primary mt-3';
   refreshButton.textContent = detectI18n.t('Refresh detection');
@@ -777,7 +777,7 @@ function addRefreshButton() {
 /**
  * 运行所有检测
  */
-function runAllDetections() {
+const runAllDetections = () => {
   fetchAndDisplayHeaders();
   detectJsLanguage();
   detectIntlApi();

--- a/detect.js
+++ b/detect.js
@@ -359,9 +359,9 @@ const fetchAndDisplayHeaders = async () => {
  * @param {number} timeoutMs - 超时时间（毫秒）
  * @returns {Promise<Object>} - 解析为第一个成功的响应数据
  */
-const fetchFromAnySource = async (urls, timeoutMs) => {
+const fetchFromAnySource = (urls, timeoutMs) => {
   const promises = urls.map(url => fetchWithTimeout(url, timeoutMs));
-  return await Promise.any(promises);
+  return Promise.any(promises);
 }
 
 /**

--- a/docs/Code_Style_Guide.md
+++ b/docs/Code_Style_Guide.md
@@ -1,0 +1,557 @@
+# MultiLangSwitcher 代码风格指南
+
+## 概述
+
+本文档定义了 MultiLangSwitcher 项目的代码风格标准，确保整个项目的代码一致性、可读性和可维护性。所有开发者都应遵循这些规范。
+
+## 目录
+
+- [JavaScript 代码风格](#javascript-代码风格)
+- [函数和变量命名](#函数和变量命名)
+- [代码结构和组织](#代码结构和组织)
+- [注释和文档](#注释和文档)
+- [错误处理](#错误处理)
+- [性能优化](#性能优化)
+- [项目特定规范](#项目特定规范)
+
+## JavaScript 代码风格
+
+### 1. ES6+ 特性使用
+
+#### ✅ 推荐做法
+
+```javascript
+// 使用 const/let 替代 var
+const API_URL = 'https://api.example.com';
+let currentLanguage = 'zh-CN';
+
+// 使用箭头函数
+const updateLanguage = (language) => {
+  return language.trim().toLowerCase();
+};
+
+// 使用模板字符串
+const message = `当前语言设置为: ${language}`;
+
+// 使用解构赋值
+const { currentLanguage, autoSwitchEnabled } = result;
+
+// 使用 async/await
+const fetchData = async () => {
+  try {
+    const response = await fetch(url);
+    return await response.json();
+  } catch (error) {
+    console.error('请求失败:', error);
+  }
+};
+```
+
+#### ❌ 避免的做法
+
+```javascript
+// 不要使用 var
+var language = 'zh-CN'; // ❌
+
+// 不要使用传统函数声明（除非必要）
+function updateLanguage(language) { // ❌
+  return language.trim().toLowerCase();
+}
+
+// 不要使用字符串拼接
+var message = '当前语言设置为: ' + language; // ❌
+
+// 不要使用 Promise.then() 链式调用（优先使用 async/await）
+fetch(url).then(response => response.json()).then(data => { // ❌
+  // 处理数据
+});
+```
+
+### 2. 函数声明规范
+
+#### 主要函数类型
+
+```javascript
+// 1. 箭头函数（推荐用于大多数情况）
+const processData = (data) => {
+  return data.filter(item => item.active);
+};
+
+// 2. 类方法（使用箭头函数语法）
+class LanguageManager {
+  /**
+   * 更新语言设置
+   * @param {string} language - 语言代码
+   */
+  updateLanguage = (language) => {
+    this.currentLanguage = language;
+  };
+}
+
+// 3. 异步函数
+const loadTranslations = async (language) => {
+  const translations = await import(`./i18n/${language}.js`);
+  return translations.default;
+};
+```
+
+### 3. 早期返回模式
+
+#### ✅ 推荐做法
+
+```javascript
+const validateLanguage = (language) => {
+  // 早期返回，减少嵌套
+  if (!language) {
+    console.error('语言代码不能为空');
+    return false;
+  }
+  
+  if (typeof language !== 'string') {
+    console.error('语言代码必须是字符串');
+    return false;
+  }
+  
+  if (language.length < 2) {
+    console.error('语言代码长度不能少于2个字符');
+    return false;
+  }
+  
+  // 主要逻辑
+  return /^[a-z]{2}(-[A-Z]{2})?$/.test(language);
+};
+```
+
+#### ❌ 避免的做法
+
+```javascript
+const validateLanguage = (language) => {
+  // 深层嵌套，难以阅读
+  if (language) {
+    if (typeof language === 'string') {
+      if (language.length >= 2) {
+        return /^[a-z]{2}(-[A-Z]{2})?$/.test(language);
+      } else {
+        console.error('语言代码长度不能少于2个字符');
+        return false;
+      }
+    } else {
+      console.error('语言代码必须是字符串');
+      return false;
+    }
+  } else {
+    console.error('语言代码不能为空');
+    return false;
+  }
+};
+```
+
+## 函数和变量命名
+
+### 1. 命名约定
+
+```javascript
+// 常量：大写字母 + 下划线
+const DEFAULT_LANGUAGE = 'zh-CN';
+const MAX_RETRY_ATTEMPTS = 3;
+
+// 变量和函数：驼峰命名法
+const currentLanguage = 'zh-CN';
+const isAutoSwitchEnabled = true;
+
+// 函数：动词开头，描述性命名
+const updateHeaderRules = (language) => { /* ... */ };
+const validateAcceptLanguage = (header) => { /* ... */ };
+const initializeDomainManager = async () => { /* ... */ };
+
+// 类：帕斯卡命名法
+class LanguageManager { /* ... */ }
+class DomainRulesManager { /* ... */ }
+
+// 私有方法：下划线前缀
+class UpdateChecker {
+  _validateVersion = (version) => { /* ... */ };
+  _handleError = (error) => { /* ... */ };
+}
+```
+
+### 2. 布尔值命名
+
+```javascript
+// 使用 is/has/can/should 前缀
+const isEnabled = true;
+const hasPermission = false;
+const canRetry = true;
+const shouldUpdate = false;
+
+// 函数返回布尔值
+const isValidLanguage = (language) => { /* ... */ };
+const hasRequiredPermissions = () => { /* ... */ };
+```
+
+## 代码结构和组织
+
+### 1. 文件结构
+
+```javascript
+// 1. 导入语句
+importScripts('shared/shared-utils.js');
+importScripts('shared/shared-i18n-base.js');
+
+// 2. 常量定义
+const RULE_ID = 1;
+const DEFAULT_LANGUAGE = 'zh-CN';
+
+// 3. 工具函数
+const sendBackgroundLog = (message, logType = 'info') => {
+  // 实现
+};
+
+// 4. 主要功能函数
+const updateHeaderRules = async (language) => {
+  // 实现
+};
+
+// 5. 事件监听器
+chrome.runtime.onMessage.addListener((request, _, sendResponse) => {
+  // 实现
+});
+```
+
+### 2. 函数组织
+
+```javascript
+// 将复杂函数拆分为多个单一职责的小函数
+const processLanguageUpdate = async (language) => {
+  const validatedLanguage = validateLanguage(language);
+  if (!validatedLanguage) return null;
+  
+  const rules = await buildLanguageRules(validatedLanguage);
+  const result = await applyRules(rules);
+  
+  return result;
+};
+
+const validateLanguage = (language) => {
+  // 验证逻辑
+};
+
+const buildLanguageRules = (language) => {
+  // 构建规则逻辑
+};
+
+const applyRules = (rules) => {
+  // 应用规则逻辑
+};
+```
+
+## 注释和文档
+
+### 1. JSDoc 注释规范
+
+```javascript
+/**
+ * 更新请求头规则，支持错误重试和规则缓存
+ * @param {string} language - 要设置的语言代码
+ * @param {number} retryCount - 当前重试次数
+ * @param {boolean} isAutoSwitch - 是否由自动切换触发
+ * @returns {Promise<Object>} 更新结果 {status: string, language: string}
+ * @throws {Error} 当规则更新失败时抛出错误
+ */
+const updateHeaderRules = async (language, retryCount = 0, isAutoSwitch = false) => {
+  // 实现
+};
+
+/**
+ * 语言管理器类
+ * 负责处理语言切换、规则管理和状态同步
+ */
+class LanguageManager {
+  /**
+   * 构造函数
+   * @param {Object} options - 配置选项
+   * @param {string} options.defaultLanguage - 默认语言
+   * @param {boolean} options.autoSwitch - 是否启用自动切换
+   */
+  constructor(options = {}) {
+    // 实现
+  }
+}
+```
+
+### 2. 行内注释
+
+```javascript
+const updateHeaderRules = async (language) => {
+  // 清理并验证语言代码
+  language = language ? language.trim() : DEFAULT_LANG_EN;
+  
+  // 检查是否需要更新（避免重复操作）
+  if (language === lastAppliedLanguage && rulesCache) {
+    return { status: 'cached', language };
+  }
+
+  try {
+    // 获取现有规则进行比较
+    const existingRules = await chrome.declarativeNetRequest.getDynamicRules();
+    
+    // 先清理所有现有规则，再添加新规则
+    await clearAllDynamicRules();
+    
+    // 添加新的语言规则
+    await chrome.declarativeNetRequest.updateDynamicRules({
+      addRules: [buildLanguageRule(language)]
+    });
+    
+    return { status: 'success', language };
+  } catch (error) {
+    // 错误处理和重试逻辑
+    return handleRuleUpdateError(error, language);
+  }
+};
+```
+
+### 3. 中文注释规范
+
+```javascript
+// ✅ 推荐：简洁明了的中文注释
+// 初始化域名规则管理器
+const initDomainManager = async () => { /* ... */ };
+
+// 处理用户语言切换请求
+const handleLanguageSwitch = (language) => { /* ... */ };
+
+// ❌ 避免：过于冗长或不必要的注释
+// 这个函数用来初始化域名规则管理器，它会加载所有的域名规则并进行初始化操作
+const initDomainManager = async () => { /* ... */ };
+```
+
+## 错误处理
+
+### 1. 统一错误处理模式
+
+```javascript
+const fetchWithRetry = async (url, options = {}, retryCount = 0) => {
+  try {
+    const response = await fetch(url, options);
+    
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+    
+    return await response.json();
+  } catch (error) {
+    // 记录错误日志
+    sendDebugLog(`请求失败: ${error.message}`, 'error');
+    
+    // 重试逻辑
+    if (retryCount < MAX_RETRY_ATTEMPTS) {
+      const delay = BASE_RETRY_DELAY * Math.pow(2, retryCount);
+      await new Promise(resolve => setTimeout(resolve, delay));
+      return fetchWithRetry(url, options, retryCount + 1);
+    }
+    
+    // 重新抛出错误供上层处理
+    throw error;
+  }
+};
+```
+
+### 2. 错误分类和处理
+
+```javascript
+const handleRuleUpdateError = async (error, language, retryCount) => {
+  // 错误分类
+  let errorType = 'unknown';
+  let canRetry = true;
+
+  if (error.message.includes('quota')) {
+    errorType = 'quota_exceeded';
+    canRetry = false;
+  } else if (error.message.includes('permission')) {
+    errorType = 'permission_denied';
+    canRetry = false;
+  } else if (error.message.includes('network')) {
+    errorType = 'network_error';
+  }
+
+  // 创建增强的错误对象
+  const enhancedError = new Error(`规则更新失败 (${errorType}): ${error.message}`);
+  enhancedError.originalError = error;
+  enhancedError.type = errorType;
+  enhancedError.canRetry = canRetry;
+  enhancedError.retryCount = retryCount;
+
+  return enhancedError;
+};
+```
+
+## 性能优化
+
+### 1. DOM 操作优化
+
+```javascript
+// 批量 DOM 更新
+let pendingDOMUpdates = [];
+let domUpdateScheduled = false;
+
+const scheduleDOMUpdate = (updateFn) => {
+  pendingDOMUpdates.push(updateFn);
+  
+  if (!domUpdateScheduled) {
+    domUpdateScheduled = true;
+    requestAnimationFrame(processPendingDOMUpdates);
+  }
+};
+
+const processPendingDOMUpdates = () => {
+  const updates = pendingDOMUpdates.splice(0);
+  updates.forEach(updateFn => {
+    try {
+      updateFn();
+    } catch (error) {
+      console.error('DOM 更新失败:', error);
+    }
+  });
+  domUpdateScheduled = false;
+};
+```
+
+### 2. 缓存和防抖
+
+```javascript
+// DOM 元素缓存
+const domCache = {
+  languageSelect: null,
+  applyButton: null,
+  currentLanguageSpan: null
+};
+
+const initializeDOMCache = () => {
+  domCache.languageSelect = document.getElementById('languageSelect');
+  domCache.applyButton = document.getElementById('applyButton');
+  domCache.currentLanguageSpan = document.getElementById('currentLanguage');
+};
+
+// 防抖函数
+const debounce = (func, delay) => {
+  let timeoutId;
+  return (...args) => {
+    clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => func.apply(this, args), delay);
+  };
+};
+
+const debouncedUpdateCheck = debounce(performUpdateCheck, 1000);
+```
+
+## 项目特定规范
+
+### 1. 国际化 (i18n) 使用
+
+```javascript
+// ✅ 推荐：使用国际化函数
+const message = backgroundI18n.t('rules_updated_successfully', { language });
+sendDebugLog(debugI18n.t('update_check_failed'), 'error');
+
+// ❌ 避免：硬编码文本
+const message = '规则更新成功: ' + language; // ❌
+sendDebugLog('更新检查失败', 'error'); // ❌
+```
+
+### 2. Chrome Extension API 使用
+
+```javascript
+// 使用 Promise 包装 Chrome API
+const getChromeStorageData = (keys) => {
+  return new Promise((resolve) => {
+    chrome.storage.local.get(keys, resolve);
+  });
+};
+
+// 事件监听器参数处理
+chrome.runtime.onMessage.addListener((request, _, sendResponse) => {
+  // 使用 _ 替代未使用的 sender 参数
+  if (request.type === 'UPDATE_RULES') {
+    handleUpdateRules(request, sendResponse);
+  }
+  return true; // 保持消息通道开放
+});
+```
+
+### 3. 调试日志规范
+
+```javascript
+// 使用统一的日志函数
+sendDebugLog('操作开始', 'info');
+sendDebugLog('操作成功完成', 'success');
+sendDebugLog('发现潜在问题', 'warning');
+sendDebugLog('操作失败', 'error');
+
+// 包含上下文信息
+sendDebugLog(`语言切换: ${oldLang} -> ${newLang}`, 'info');
+sendDebugLog(`规则更新失败: ${error.message}`, 'error');
+```
+
+## 代码审查检查清单
+
+在提交代码前，请确保：
+
+### ✅ 基本检查
+- [ ] 使用 `const`/`let` 替代 `var`
+- [ ] 函数使用箭头函数语法
+- [ ] 使用模板字符串替代字符串拼接
+- [ ] 应用早期返回模式减少嵌套
+- [ ] 移除未使用的变量和参数
+
+### ✅ 函数和命名
+- [ ] 函数名清晰描述其功能
+- [ ] 变量名使用驼峰命名法
+- [ ] 常量使用大写字母和下划线
+- [ ] 布尔值使用 is/has/can 前缀
+
+### ✅ 注释和文档
+- [ ] 复杂函数有 JSDoc 注释
+- [ ] 关键逻辑有行内注释
+- [ ] 注释使用中文且简洁明了
+
+### ✅ 错误处理
+- [ ] 异步操作有 try-catch 块
+- [ ] 错误信息有意义且可调试
+- [ ] 适当的错误重试机制
+
+### ✅ 性能优化
+- [ ] DOM 操作进行了批量处理
+- [ ] 频繁调用的函数进行了防抖
+- [ ] 重复使用的 DOM 元素进行了缓存
+
+### ✅ 项目特定
+- [ ] 使用国际化函数而非硬编码文本
+- [ ] Chrome API 调用有适当的错误处理
+- [ ] 调试日志使用统一的格式
+
+## 工具和配置
+
+### 推荐的开发工具
+- **ESLint**: 代码质量检查
+- **Prettier**: 代码格式化
+- **JSDoc**: 文档生成
+- **Chrome DevTools**: 调试和性能分析
+
+### VS Code 推荐插件
+- ESLint
+- Prettier
+- JavaScript (ES6) code snippets
+- Auto Rename Tag
+- Bracket Pair Colorizer
+
+---
+
+## 更新历史
+
+- **v1.8.52**: 初始版本，基于项目代码风格统一工作总结
+- 后续版本将根据项目发展需要更新此指南
+
+---
+
+*本指南是活文档，会随着项目的发展而持续更新。如有建议或问题，请提交 Issue 或 Pull Request。*

--- a/docs/Update.md
+++ b/docs/Update.md
@@ -85,7 +85,7 @@
 - debug-i18n.js、detect-i18n.js、popup-i18n.js - 引入统一的 fallback 系统（v1.8.31），重构为继承BaseI18n基础类，简化代码结构（v1.8.50）
 - shared/shared-language-options.js - 优化语言选项生成的缓存机制（v1.8.31），更新语言选项描述（v1.8.51）
 - shared/shared-utils.js - 创建通用 fallback 翻译系统（v1.8.31），添加中文注释和统一代码风格（v1.8.40）
-- background.js - 更新脚本导入顺序，添加shared-i18n-base.js引用（v1.8.50），统一代码风格，转换函数为箭头函数，移除未使用参数，优化事件监听器，重构消息处理器减少深层嵌套，提取单一职责的处理函数（v1.8.52）
+- background.js - 更新脚本导入顺序，添加shared-i18n-base.js引用（v1.8.50），统一代码风格，转换函数为箭头函数，移除未使用参数，优化事件监听器，重构消息处理器减少深层嵌套，提取单一职责的处理函数；修复硬编码的版本获取（v1.8.52）
 - i18n/popup-en.js、popup-zh.js、debug-en.js、debug-zh.js、detect-en.js、detect-zh.js、background-en.js、background-zh.js、domain-manager-en.js、domain-manager-zh.js - 添加防重复声明机制，支持安全的多次加载（v1.8.50）
 
 ### 移除内容

--- a/docs/Update.md
+++ b/docs/Update.md
@@ -1,4 +1,4 @@
-# v1.8.51（含迭代内容）
+# v1.8.52（含迭代内容）
 
 ## 主要改动
 
@@ -28,13 +28,16 @@
 - ✅ 优化语言选项表生成的缓存机制（v1.8.31）
 - ✅ 提取单一职责的工具方法（v1.8.50）
 - ✅ 统一Service Worker和浏览器环境的翻译加载逻辑（v1.8.50）
+- ✅ 统一多个核心文件代码风格，应用项目标准和现代JavaScript最佳实践（v1.8.52）
 
 ### 3. 文档完善
 
 - ✅ TODO 更新（v1.8.27、v1.8.28）
-- ✅ 更新项目结构文档（v1.8.27、v1.8.28）
+- ✅ 更新项目结构文档（v1.8.27、v1.8.28、v1.8.50）
 - ✅ README 内容与引用图片同步更新（v1.8.27、v1.8.28）
-- ✅ Update 更新文档内容更新（v1.8.27、v1.8.28、v1.8.29、v1.8.30、v1.8.31、v1.8.40、v1.8.50）
+- ✅ Update 更新文档内容更新（v1.8.27、v1.8.28、v1.8.29、v1.8.30、v1.8.31、v1.8.40、v1.8.50、v1.8.51、v1.8.52）
+- ✅ 添加国际化系统使用指南文档（v1.8.50）
+- ✅ 添加代码风格指南文档（v1.8.52）
 
 
 ## 文件变更清单
@@ -44,6 +47,7 @@
 - Update.md - 版本更新文档（v1.8.27）
 - shared/shared-i18n-base.js - 基础国际化类，提供通用翻译功能（v1.8.50）
 - docs/I18n_Usage_Guide.md - 国际化系统使用指南文档（v1.8.50）
+- docs/Code_Style_Guide.md - 代码风格指南文档（v1.8.52）
 
 ### 重命名文件
 
@@ -56,20 +60,23 @@
 ### 修改文件
 
 - README.md、README_EN.md - 内容与引用图片同步更新（v1.8.27、v1.8.28）
-- manifest.json - 版本号更新（v1.8.27、v1.8.28、v1.8.29、v1.8.30、v1.8.31、v1.8.40、v1.8.50、v1.8.51）
+- manifest.json - 版本号更新（v1.8.27、v1.8.28、v1.8.29、v1.8.30、v1.8.31、v1.8.40、v1.8.50、v1.8.51、v1.8.52）
 - docs/TODO.md - 更新任务完成状态（v1.8.27、v1.8.28、v1.8.30、v1.8.40）
 - Project_Structure.md - 项目结构更新（v1.8.27、v1.8.28、v1.8.51）
 - Update.md - 更新文档内容更新（v1.8.27、v1.8.28、v1.8.29）
 - /images - icons更新（v1.8.27、v1.8.51）
 - detect.html - 更新脚本引用路径（v1.8.28）
-- detect.js - 更新i18n对象引用（testI18n → detectI18n）（v1.8.28）
+- detect.js - 更新i18n对象引用（testI18n → detectI18n）（v1.8.28），统一代码风格，转换所有函数为箭头函数，优化浏览器检测和指纹识别功能（v1.8.52）
 - i18n/detect-i18n.js - 更新类名和变量名（TestI18n → DetectI18n）（v1.8.28）
 - i18n/detect-en.js - 更新变量名（testEn → detectEn）（v1.8.28）
 - i18n/detect-zh.js - 更新变量名（testZh → detectZh）（v1.8.28）
 - popup.html - 更新检测页面链接（v1.8.28）
 - i18n/popup-en.js、popup-zh.js - 调整翻译，删除重复键（v1.8.28）
 - i18n/domain-manager-i18n.js、i18n/background-i18n.js - 重构代码，优化翻译加载逻辑，增强错误处理（v1.8.29），引入统一的 fallback 系统（v1.8.31），重构为继承BaseI18n基础类（v1.8.50）
-- debug-ui.js - 添加 Accept-Language 格式验证和用户友好提醒（v1.8.30）
+- debug-ui.js - 添加 Accept-Language 格式验证和用户友好提醒（v1.8.30），统一代码风格，转换为箭头函数和现代JavaScript语法（v1.8.52）
+- debug-headers.js - 统一代码风格，转换为箭头函数，应用早期返回模式和模板字符串（v1.8.52）
+- domain-rules-manager.js - 重大重构，拆分复杂方法为单一职责的私有方法，添加完整JSDoc注释，优化规则匹配逻辑（v1.8.52）
+- toggle.js - 统一代码风格，将类方法转换为箭头函数，添加完整JSDoc注释，优化主题和语言切换功能（v1.8.52）
 - i18n/debug-en.js、debug-zh.js - 添加格式验证相关翻译键（v1.8.30）
 - i18n/background-en.js、background-zh.js - 添加更新检查器相关翻译（v1.8.30）
 - shared/shared-update-checker.js - 国际化所有英文日志消息（v1.8.31）
@@ -78,7 +85,7 @@
 - debug-i18n.js、detect-i18n.js、popup-i18n.js - 引入统一的 fallback 系统（v1.8.31），重构为继承BaseI18n基础类，简化代码结构（v1.8.50）
 - shared/shared-language-options.js - 优化语言选项生成的缓存机制（v1.8.31），更新语言选项描述（v1.8.51）
 - shared/shared-utils.js - 创建通用 fallback 翻译系统（v1.8.31），添加中文注释和统一代码风格（v1.8.40）
-- background.js - 更新脚本导入顺序，添加shared-i18n-base.js引用（v1.8.50）
+- background.js - 更新脚本导入顺序，添加shared-i18n-base.js引用（v1.8.50），统一代码风格，转换函数为箭头函数，移除未使用参数，优化事件监听器，重构消息处理器减少深层嵌套，提取单一职责的处理函数（v1.8.52）
 - i18n/popup-en.js、popup-zh.js、debug-en.js、debug-zh.js、detect-en.js、detect-zh.js、background-en.js、background-zh.js、domain-manager-en.js、domain-manager-zh.js - 添加防重复声明机制，支持安全的多次加载（v1.8.50）
 
 ### 移除内容

--- a/domain-rules-manager.js
+++ b/domain-rules-manager.js
@@ -24,13 +24,19 @@ class DomainRulesManager {
     return this.loadPromise;
   }
 
+  /**
+   * 从文件加载规则数据
+   * @returns {Promise<Object>} 规则数据
+   * @private
+   */
   async _loadRulesFromFile() {
+    const i18n = this.ensureI18n();
+
     try {
       const url = chrome.runtime.getURL('domain-rules.json');
-      const i18n = this.ensureI18n();
       console.log(`[DomainRulesManager] ${i18n ? i18n.t('trying_load_rules_file') : 'Trying to load rules file'}:`, url);
-      const response = await fetch(url);
 
+      const response = await fetch(url);
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
       }
@@ -38,15 +44,16 @@ class DomainRulesManager {
       const data = await response.json();
       console.log(`[DomainRulesManager] ${i18n ? i18n.t('rules_file_loaded_success') : 'Rules file loaded successfully'}:`, Object.keys(data));
 
-      if (data.domainLanguageRules) {
-        this.rules = data.domainLanguageRules;
-        console.log(`[DomainRulesManager] ${i18n ? i18n.t('domain_rules_loaded_count', { count: Object.keys(this.rules).length }) : `Successfully loaded ${Object.keys(this.rules).length} domain rules`}`);
-      } else {
+      if (!data.domainLanguageRules) {
         console.warn(`[DomainRulesManager] ${i18n ? i18n.t('domain_rules_field_not_found') : 'domainLanguageRules field not found in rules file'}`);
         this.rules = {};
+        return this.rules;
       }
 
+      this.rules = data.domainLanguageRules;
+      console.log(`[DomainRulesManager] ${i18n ? i18n.t('domain_rules_loaded_count', { count: Object.keys(this.rules).length }) : `Successfully loaded ${Object.keys(this.rules).length} domain rules`}`);
       return this.rules;
+
     } catch (error) {
       console.error(`[DomainRulesManager] ${i18n ? i18n.t('domain_rules_load_failed') : 'Failed to load domain rules'}:`, error);
       this.rules = {};
@@ -64,17 +71,17 @@ class DomainRulesManager {
     return this.rules;
   }
 
-  // 根据域名获取语言
+  /**
+   * 根据域名获取对应的语言
+   * @param {string} domain - 域名
+   * @returns {Promise<string|null>} 语言代码或null
+   */
   async getLanguageForDomain(domain) {
     const i18n = this.ensureI18n();
     console.log(`[DomainRulesManager] ${i18n ? i18n.t('searching_domain') : 'Searching domain'}: ${domain}`);
 
     // 确保规则已加载
-    if (!this.rules) {
-      console.log(`[DomainRulesManager] ${i18n ? i18n.t('rules_not_loaded_loading') : 'Rules not loaded, loading now...'}`);
-      await this.loadRules();
-    }
-
+    await this._ensureRulesLoaded();
     if (!this.rules) {
       console.warn(`[DomainRulesManager] ${i18n ? i18n.t('loading_rules_failed') : 'Loading rules failed'}`);
       return null;
@@ -82,47 +89,112 @@ class DomainRulesManager {
 
     console.log(`[DomainRulesManager] ${i18n ? i18n.t('loaded_rules_count', { count: Object.keys(this.rules).length }) : `Loaded ${Object.keys(this.rules).length} rules`}`);
 
-    // 优先检查自定义规则
+    // 获取自定义规则
     const customRules = await this.getCustomRules();
-    if (customRules[domain]) {
-      console.log(`[DomainRulesManager] ${i18n ? i18n.t('found_in_custom_rules') : 'Found in custom rules'}: ${domain} -> ${customRules[domain]}`);
-      return customRules[domain];
+
+    // 按优先级检查规则：自定义完整域名 > 内置完整域名 > 自定义二级域名 > 内置二级域名 > 自定义顶级域名 > 内置顶级域名
+    const result = this._findMatchingRule(domain, customRules, this.rules);
+
+    if (result) {
+      console.log(`[DomainRulesManager] ${i18n ? i18n.t('found_matching_rule') : 'Found matching rule'}: ${domain} -> ${result.language} (${result.source})`);
+      return result.language;
     }
 
+    this._logNoMatchFound(domain, i18n);
+    return null;
+  }
+
+  /**
+   * 确保规则已加载
+   * @private
+   */
+  async _ensureRulesLoaded() {
+    if (!this.rules) {
+      const i18n = this.ensureI18n();
+      console.log(`[DomainRulesManager] ${i18n ? i18n.t('rules_not_loaded_loading') : 'Rules not loaded, loading now...'}`);
+      await this.loadRules();
+    }
+  }
+
+  /**
+   * 查找匹配的规则
+   * @param {string} domain - 域名
+   * @param {Object} customRules - 自定义规则
+   * @param {Object} defaultRules - 默认规则
+   * @returns {Object|null} 匹配结果 {language, source} 或 null
+   * @private
+   */
+  _findMatchingRule(domain, customRules, defaultRules) {
+    const i18n = this.ensureI18n();
+
     // 检查完整域名
-    if (this.rules[domain]) {
-      console.log(`[DomainRulesManager] ${i18n ? i18n.t('found_in_full_domain') : 'Found in full domain'}: ${domain} -> ${this.rules[domain]}`);
-      return this.rules[domain];
+    if (customRules[domain]) {
+      console.log(`[DomainRulesManager] ${i18n ? i18n.t('found_in_custom_rules') : 'Found in custom rules'}: ${domain}`);
+      return { language: customRules[domain], source: 'custom-full' };
+    }
+
+    if (defaultRules[domain]) {
+      console.log(`[DomainRulesManager] ${i18n ? i18n.t('found_in_full_domain') : 'Found in full domain'}: ${domain}`);
+      return { language: defaultRules[domain], source: 'default-full' };
+    }
+
+    // 解析域名部分
+    const parts = domain.split('.');
+    if (parts.length < 2) {
+      return null; // 无效域名
     }
 
     // 检查二级域名
-    const parts = domain.split('.');
-    if (parts.length >= 2) {
-      const secondLevel = parts.slice(-2).join('.');
-      console.log(`[DomainRulesManager] ${i18n ? i18n.t('checking_second_level') : 'Checking second-level domain'}: ${secondLevel}`);
-      if (customRules[secondLevel] || this.rules[secondLevel]) {
-        const result = customRules[secondLevel] || this.rules[secondLevel];
-        console.log(`[DomainRulesManager] ${i18n ? i18n.t('found_in_second_level') : 'Found in second-level domain'}: ${secondLevel} -> ${result}`);
-        return result;
-      }
+    const secondLevel = parts.slice(-2).join('.');
+    console.log(`[DomainRulesManager] ${i18n ? i18n.t('checking_second_level') : 'Checking second-level domain'}: ${secondLevel}`);
+
+    if (customRules[secondLevel]) {
+      console.log(`[DomainRulesManager] ${i18n ? i18n.t('found_in_second_level') : 'Found in second-level domain'}: ${secondLevel}`);
+      return { language: customRules[secondLevel], source: 'custom-second' };
+    }
+
+    if (defaultRules[secondLevel]) {
+      console.log(`[DomainRulesManager] ${i18n ? i18n.t('found_in_second_level') : 'Found in second-level domain'}: ${secondLevel}`);
+      return { language: defaultRules[secondLevel], source: 'default-second' };
     }
 
     // 检查顶级域名
     const topLevel = parts[parts.length - 1];
     console.log(`[DomainRulesManager] ${i18n ? i18n.t('checking_top_level') : 'Checking top-level domain'}: ${topLevel}`);
-    console.log(`[DomainRulesManager] ${i18n ? i18n.t('available_top_level_rules') : 'Available top-level domain rules'}:`, Object.keys(this.rules).filter(k => !k.includes('.')).slice(0, 10));
-    if (customRules[topLevel] || this.rules[topLevel]) {
-      const result = customRules[topLevel] || this.rules[topLevel];
-      console.log(`[DomainRulesManager] ${i18n ? i18n.t('found_in_top_level') : 'Found in top-level domain'}: ${topLevel} -> ${result}`);
-      return result;
+    console.log(`[DomainRulesManager] ${i18n ? i18n.t('available_top_level_rules') : 'Available top-level domain rules'}:`, Object.keys(defaultRules).filter(k => !k.includes('.')).slice(0, 10));
+
+    if (customRules[topLevel]) {
+      console.log(`[DomainRulesManager] ${i18n ? i18n.t('found_in_top_level') : 'Found in top-level domain'}: ${topLevel}`);
+      return { language: customRules[topLevel], source: 'custom-top' };
     }
 
-    console.log(`[DomainRulesManager] ${i18n ? i18n.t('no_matching_rule_found') : 'No matching rule found for domain'}: ${domain}`);
-    console.log(`[DomainRulesManager] ${i18n ? i18n.t('domain_parse_result') : 'Domain parse result - Full'}: ${domain}, ${i18n ? i18n.t('second_level') : 'Second-level'}: ${parts.length >= 2 ? parts.slice(-2).join('.') : 'N/A'}, ${i18n ? i18n.t('top_level') : 'Top-level'}: ${topLevel}`);
+    if (defaultRules[topLevel]) {
+      console.log(`[DomainRulesManager] ${i18n ? i18n.t('found_in_top_level') : 'Found in top-level domain'}: ${topLevel}`);
+      return { language: defaultRules[topLevel], source: 'default-top' };
+    }
+
     return null;
   }
 
-  // 获取自定义规则
+  /**
+   * 记录未找到匹配规则的日志
+   * @param {string} domain - 域名
+   * @param {Object} i18n - 国际化实例
+   * @private
+   */
+  _logNoMatchFound(domain, i18n) {
+    const parts = domain.split('.');
+    const secondLevel = parts.length >= 2 ? parts.slice(-2).join('.') : 'N/A';
+    const topLevel = parts[parts.length - 1];
+
+    console.log(`[DomainRulesManager] ${i18n ? i18n.t('no_matching_rule_found') : 'No matching rule found for domain'}: ${domain}`);
+    console.log(`[DomainRulesManager] ${i18n ? i18n.t('domain_parse_result') : 'Domain parse result - Full'}: ${domain}, ${i18n ? i18n.t('second_level') : 'Second-level'}: ${secondLevel}, ${i18n ? i18n.t('top_level') : 'Top-level'}: ${topLevel}`);
+  }
+
+  /**
+   * 获取自定义规则
+   * @returns {Promise<Object>} 自定义规则对象
+   */
   async getCustomRules() {
     try {
       const result = await chrome.storage.local.get(['customDomainRules']);
@@ -134,7 +206,10 @@ class DomainRulesManager {
     }
   }
 
-  // 获取规则统计信息（用于调试）
+  /**
+   * 获取规则统计信息（用于调试）
+   * @returns {Object} 统计信息对象
+   */
   getRulesStats() {
     const rules = this.getRules();
     const stats = {
@@ -142,13 +217,15 @@ class DomainRulesManager {
       languageDistribution: {}
     };
 
-    if (rules && typeof rules === 'object') {
-      Object.values(rules).forEach(lang => {
-        if (lang) {
-          stats.languageDistribution[lang] = (stats.languageDistribution[lang] || 0) + 1;
-        }
-      });
+    if (!rules || typeof rules !== 'object') {
+      return stats;
     }
+
+    Object.values(rules).forEach(lang => {
+      if (lang) {
+        stats.languageDistribution[lang] = (stats.languageDistribution[lang] || 0) + 1;
+      }
+    });
 
     return stats;
   }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "MultiLangSwitcher",
-  "version": "1.8.51",
+  "version": "1.8.52",
   "minimum_chrome_version": "88.0",
   "description": "__MSG_extension_description__",
   "default_locale": "zh",

--- a/toggle.js
+++ b/toggle.js
@@ -6,21 +6,32 @@ class LanguageToggle {
     this.currentLang = this.detectLanguage();
   }
 
-  detectLanguage() {
+  /**
+   * 检测当前语言设置
+   * @returns {string} 语言代码 ('zh' 或 'en')
+   */
+  detectLanguage = () => {
     const saved = localStorage.getItem('app-lang');
     if (saved) return saved;
     return navigator.language.startsWith('zh') ? 'zh' : 'en';
-  }
+  };
 
-  async switchLanguage(lang) {
+  /**
+   * 切换语言设置
+   * @param {string} lang - 目标语言代码
+   */
+  switchLanguage = async (lang) => {
     if (lang === this.currentLang) return;
-    
+
     this.currentLang = lang;
     localStorage.setItem('app-lang', lang);
     location.reload();
-  }
+  };
 
-  addLanguageSelector() {
+  /**
+   * 添加语言选择器按钮到页面
+   */
+  addLanguageSelector = () => {
     const langBtn = document.createElement('button');
     langBtn.id = 'langToggleBtn';
     langBtn.className = 'toggle';
@@ -36,16 +47,18 @@ class LanguageToggle {
     langBtn.addEventListener('click', () => {
       this.switchLanguage(this.currentLang === 'zh' ? 'en' : 'zh');
     });
-  }
+  };
 }
 
-// 主题管理功能
+/**
+ * 主题管理功能类
+ */
 class ThemeManager {
   constructor() {
     this.themeToggleBtn = document.getElementById('themeToggleBtn');
     this.currentTheme = localStorage.getItem('theme') || null;
     this.prefersDarkScheme = window.matchMedia('(prefers-color-scheme: dark)');
-    
+
     this.themeButtonDetails = {
       'dark': {
         icon: '<img src="images/sun.svg" alt="Light Mode" width="16" height="16" class="invert-on-dark">',
@@ -58,7 +71,10 @@ class ThemeManager {
     };
   }
 
-  init() {
+  /**
+   * 初始化主题管理器
+   */
+  init = () => {
     // 应用初始主题
     if (this.currentTheme) {
       this.applyTheme(this.currentTheme);
@@ -67,22 +83,29 @@ class ThemeManager {
     }
 
     this.setupEventListeners();
-  }
+  };
 
-  applyTheme(theme) {
+  /**
+   * 应用指定主题
+   * @param {string} theme - 主题名称 ('dark' 或 'light')
+   */
+  applyTheme = (theme) => {
     document.documentElement.setAttribute('data-bs-theme', theme);
     localStorage.setItem('theme', theme);
 
     if (!this.themeToggleBtn) return;
-    
+
     const details = this.themeButtonDetails[theme];
     if (details) {
       this.themeToggleBtn.innerHTML = details.icon;
       this.themeToggleBtn.setAttribute('data-state', details.state);
     }
-  }
+  };
 
-  setupEventListeners() {
+  /**
+   * 设置事件监听器
+   */
+  setupEventListeners = () => {
     // 主题切换按钮监听器
     if (this.themeToggleBtn) {
       this.themeToggleBtn.addEventListener('click', () => {
@@ -99,11 +122,13 @@ class ThemeManager {
         this.applyTheme(e.matches ? 'dark' : 'light');
       }
     });
-  }
+  };
 }
 
-// 初始化页面功能
-async function initializePage() {
+/**
+ * 初始化页面功能
+ */
+const initializePage = async () => {
   try {
     // 初始化主题管理
     const themeManager = new ThemeManager();
@@ -115,7 +140,7 @@ async function initializePage() {
   } catch (error) {
     console.error('Error initializing page:', error);
   }
-}
+};
 
 // 监听页面加载，初始化按钮和主题状态
 document.addEventListener('DOMContentLoaded', initializePage);


### PR DESCRIPTION
# v1.8.52（含迭代内容）

## 主要改动

### 1. 功能增强

- ✅ 完善HTML相关i18n的错误处理，增加回退机制（v1.8.27）
- ✅ 优化HTML相关i18n实现，均在页面加载前检测用户语言并加载相应的语言文件（v1.8.27）
- ✅ 重构domain-manager-i18n.js，优化翻译加载逻辑，增加回退机制（v1.8.29）
- ✅ 重构background-i18n.js，优化翻译加载逻辑，增强错误处理（v1.8.29）
- ✅ 完善自定义 Accept-Language 格式验证逻辑，增加用户友好的提醒功能（v1.8.30）
- ✅ 增强调试页面自定义 Accept-Language 的格式检查与国际化的提醒（v1.8.30）
- ✅ 新增统一的 fallback 系统作为回退机制（v1.8.31）
- ✅ 使用通用 fallback 系统，避免依赖异步加载的 debugI18n（v1.8.31）
- ✅ 使用fallback处理更新检查器消息的翻译（v1.8.31）
- ✅ 重构所有i18n类文件，减少代码重复和深层嵌套（v1.8.40）
- ✅ 提取BaseI18n基础国际化类，统一所有i18n组件的继承结构（v1.8.50）
- ✅ 添加防重复声明机制，修复翻译文件加载冲突问题（v1.8.50）

### 2. 代码优化

- ✅ 优化HTML的i18n结构，不包含任何硬编码文本，使用 ID 属性标识需要国际化的元素（v1.8.27）
- ✅ 将test-headers相关文件重命名为detect，统一命名规范（v1.8.28）
- ✅ 更新所有相关引用，包括HTML、JavaScript和文档（v1.8.28）
- ✅ 优化i18n类名和变量名，从TestI18n改为DetectI18n（v1.8.28）
- ✅ 添加字体预加载（v1.8.30）
- ✅ 改进Fallback方法（v1.8.31）
- ✅ 优化语言选项表生成的缓存机制（v1.8.31）
- ✅ 提取单一职责的工具方法（v1.8.50）
- ✅ 统一Service Worker和浏览器环境的翻译加载逻辑（v1.8.50）
- ✅ 统一多个核心文件代码风格，应用项目标准和现代JavaScript最佳实践（v1.8.52）

### 3. 文档完善

- ✅ TODO 更新（v1.8.27、v1.8.28）
- ✅ 更新项目结构文档（v1.8.27、v1.8.28、v1.8.50）
- ✅ README 内容与引用图片同步更新（v1.8.27、v1.8.28）
- ✅ Update 更新文档内容更新（v1.8.27、v1.8.28、v1.8.29、v1.8.30、v1.8.31、v1.8.40、v1.8.50、v1.8.51、v1.8.52）
- ✅ 添加国际化系统使用指南文档（v1.8.50）
- ✅ 添加代码风格指南文档（v1.8.52）


## 文件变更清单

### 新增文件

- Update.md - 版本更新文档（v1.8.27）
- shared/shared-i18n-base.js - 基础国际化类，提供通用翻译功能（v1.8.50）
- docs/I18n_Usage_Guide.md - 国际化系统使用指南文档（v1.8.50）
- docs/Code_Style_Guide.md - 代码风格指南文档（v1.8.52）

### 重命名文件

- test-headers.html → detect.html - 检测页面HTML（v1.8.28）
- test-headers.js → detect.js - 检测页面JavaScript（v1.8.28）
- i18n/test-en.js → i18n/detect-en.js - 检测页面英文翻译（v1.8.28）
- i18n/test-i18n.js → i18n/detect-i18n.js - 检测页面国际化配置（v1.8.28）
- i18n/test-zh.js → i18n/detect-zh.js - 检测页面中文翻译（v1.8.28）

### 修改文件

- README.md、README_EN.md - 内容与引用图片同步更新（v1.8.27、v1.8.28）
- manifest.json - 版本号更新（v1.8.27、v1.8.28、v1.8.29、v1.8.30、v1.8.31、v1.8.40、v1.8.50、v1.8.51、v1.8.52）
- docs/TODO.md - 更新任务完成状态（v1.8.27、v1.8.28、v1.8.30、v1.8.40）
- Project_Structure.md - 项目结构更新（v1.8.27、v1.8.28、v1.8.51）
- Update.md - 更新文档内容更新（v1.8.27、v1.8.28、v1.8.29）
- /images - icons更新（v1.8.27、v1.8.51）
- detect.html - 更新脚本引用路径（v1.8.28）
- detect.js - 更新i18n对象引用（testI18n → detectI18n）（v1.8.28），统一代码风格，转换所有函数为箭头函数，优化浏览器检测和指纹识别功能（v1.8.52）
- i18n/detect-i18n.js - 更新类名和变量名（TestI18n → DetectI18n）（v1.8.28）
- i18n/detect-en.js - 更新变量名（testEn → detectEn）（v1.8.28）
- i18n/detect-zh.js - 更新变量名（testZh → detectZh）（v1.8.28）
- popup.html - 更新检测页面链接（v1.8.28）
- i18n/popup-en.js、popup-zh.js - 调整翻译，删除重复键（v1.8.28）
- i18n/domain-manager-i18n.js、i18n/background-i18n.js - 重构代码，优化翻译加载逻辑，增强错误处理（v1.8.29），引入统一的 fallback 系统（v1.8.31），重构为继承BaseI18n基础类（v1.8.50）
- debug-ui.js - 添加 Accept-Language 格式验证和用户友好提醒（v1.8.30），统一代码风格，转换为箭头函数和现代JavaScript语法（v1.8.52）
- debug-headers.js - 统一代码风格，转换为箭头函数，应用早期返回模式和模板字符串（v1.8.52）
- domain-rules-manager.js - 重大重构，拆分复杂方法为单一职责的私有方法，添加完整JSDoc注释，优化规则匹配逻辑（v1.8.52）
- toggle.js - 统一代码风格，将类方法转换为箭头函数，添加完整JSDoc注释，优化主题和语言切换功能（v1.8.52）
- i18n/debug-en.js、debug-zh.js - 添加格式验证相关翻译键（v1.8.30）
- i18n/background-en.js、background-zh.js - 添加更新检查器相关翻译（v1.8.30）
- shared/shared-update-checker.js - 国际化所有英文日志消息（v1.8.31）
- shared/shared-utils.js - 创建通用 fallback 翻译系统（v1.8.31）
- popup.html、debug.html、detect.html - 添加字体预加载优化（v1.8.31），更新脚本引入顺序，添加shared-i18n-base.js引用（v1.8.50）
- debug-i18n.js、detect-i18n.js、popup-i18n.js - 引入统一的 fallback 系统（v1.8.31），重构为继承BaseI18n基础类，简化代码结构（v1.8.50）
- shared/shared-language-options.js - 优化语言选项生成的缓存机制（v1.8.31），更新语言选项描述（v1.8.51）
- shared/shared-utils.js - 创建通用 fallback 翻译系统（v1.8.31），添加中文注释和统一代码风格（v1.8.40）
- background.js - 更新脚本导入顺序，添加shared-i18n-base.js引用（v1.8.50），统一代码风格，转换函数为箭头函数，移除未使用参数，优化事件监听器，重构消息处理器减少深层嵌套，提取单一职责的处理函数（v1.8.52）
- i18n/popup-en.js、popup-zh.js、debug-en.js、debug-zh.js、detect-en.js、detect-zh.js、background-en.js、background-zh.js、domain-manager-en.js、domain-manager-zh.js - 添加防重复声明机制，支持安全的多次加载（v1.8.50）

### 移除内容

- 以 `test-headers` 命名的相关文件与引用（v1.8.28）
- i18n类中未使用的辅助方法（v1.8.29）