### PR TITLE
ver: update to v1.8.69

### DIFF
--- a/background.js
+++ b/background.js
@@ -31,6 +31,22 @@ const sendBackgroundLog = (message, logType = 'info') => {
   sendDebugLog(`[${backgroundLabel}] ${message}`, logType);
 };
 
+/**
+ * 确保初始化已完成的守卫函数
+ * @returns {Promise}
+ */
+const ensureInitialized = async () => {
+  // 如果isInitialized为true，但initializationPromise仍在进行中，则等待它完成
+  if (initializationPromise && !isInitialized) {
+    await initializationPromise;
+  }
+  
+  // 如果尚未初始化，则调用initialize
+  if (!isInitialized) {
+    sendBackgroundLog('Lazy initialization triggered.', 'info');
+    await initialize('lazy');
+  }
+};
 // 全局状态变量
 let rulesCache = null;          // 规则缓存，避免重复获取已知规则
 let lastAppliedLanguage = null; // 最后应用的语言
@@ -38,6 +54,8 @@ let autoSwitchEnabled = false;  // 自动切换状态
 let pendingUIUpdate = null;     // 待处理的UI更新
 let latestAutoSwitchEnabled = false; // 用于存储最新的 autoSwitchEnabled 状态
 let latestCurrentLanguage = null;    // 用于存储最新的 currentLanguage 状态
+let isInitialized = false;           // 初始化完成标志
+let initializationPromise = null;    // 初始化Promise，防止重复执行
 
 // 右键菜单初始化标志
 let contextMenusCreated = false;
@@ -90,26 +108,13 @@ const getLanguageForDomain = (domain) => {
 };
 
 
-/**
- * 初始化域名规则管理器
- * @returns {Promise<void>}
- */
-const initDomainRulesManager = async () => {
-  try {
-    await domainRulesManager.loadRules();
-    sendBackgroundLog(backgroundI18n.t('domain_rules_loaded'), 'info');
-  } catch (error) {
-    sendBackgroundLog(`${backgroundI18n.t('domain_rules_load_failed')}: ${error.message}`, 'error');
-  }
-};
 
 // 在浏览器启动时初始化
 chrome.runtime.onStartup.addListener(() => {
-  initializeState('startup');
+  initialize('startup');
 });
 
 // 在扩展安装或更新时初始化
-chrome.runtime.onInstalled.addListener(initDomainRulesManager);
 
 // 指数退避重试配置
 const MAX_RETRY_ATTEMPTS = 3;
@@ -117,8 +122,6 @@ const BASE_RETRY_DELAY = 500; // 毫秒
 
 /**
  * 清理所有动态规则
- * @returns {Promise<void>}
- */
 const clearAllDynamicRules = async () => {
   try {
     const existingRules = await chrome.declarativeNetRequest.getDynamicRules();
@@ -290,14 +293,15 @@ const handleRuleUpdateError = async (error, language, retryCount) => {
 
 
 /**
- * 统一的初始化函数，用于设置扩展的初始状态
- * @param {string} reason - 触发初始化的原因 (e.g., 'install', 'update', 'startup')
+ * 执行核心初始化逻辑
+ * @param {string} reason - 初始化的原因 (e.g., 'install', 'update', 'startup')
  */
-const initializeState = async (reason) => {
+const performInitialization = async (reason) => {
   sendBackgroundLog(backgroundI18n.t('initializing_state', { reason }), 'info');
   try {
-    // 1. 初始化域名规则管理器
-    await initDomainRulesManager();
+    // 1. 初始化域名规则管理器 (现在直接加载)
+    await domainRulesManager.loadRules();
+    sendBackgroundLog(backgroundI18n.t('domain_rules_loaded'), 'info');
 
     // 2. 从存储中获取设置
     const result = await new Promise((resolve, reject) => {
@@ -309,40 +313,15 @@ const initializeState = async (reason) => {
         resolve(result);
       });
     });
-    autoSwitchEnabled = !!result.autoSwitchEnabled;
+    autoSwitchEnabled = result.autoSwitchEnabled !== false; // 默认为 true
     sendBackgroundLog(`${backgroundI18n.t('loaded_auto_switch_status')}: ${autoSwitchEnabled}`, 'info');
 
-    let initialLanguage = null;
-    let isAuto = autoSwitchEnabled;
-
-    if (autoSwitchEnabled) {
-      // 如果自动切换开启，则应用默认的回退语言
-      initialLanguage = DEFAULT_LANG_EN;
-      sendBackgroundLog(backgroundI18n.t('auto_switch_enabled_default_lang', { language: initialLanguage }), 'info');
-    } else if (result.currentLanguage) {
-      // 如果有关闭自动切换且有已保存的语言
-      initialLanguage = result.currentLanguage;
-      sendBackgroundLog(`${backgroundI18n.t('loaded_applied_language')}: ${initialLanguage}`, 'info');
-    } else {
-      // 首次安装，检测浏览器语言
-      const detectedLang = detectBrowserLanguage();
-      const lang = detectedLang === 'zh' ? DEFAULT_LANG_ZH : DEFAULT_LANG_EN;
-      initialLanguage = lang;
-      sendBackgroundLog(`${backgroundI18n.t('first_install_detected_lang')}: ${detectedLang} -> ${initialLanguage}`, 'info');
-      // 将首次设置的语言保存到存储中
-      await chrome.storage.local.set({ currentLanguage: initialLanguage });
-    }
-
-    // 3. 应用请求头规则
-    if (initialLanguage) {
-      await updateHeaderRules(initialLanguage, 0, isAuto);
-    } else {
-      // 如果没有目标语言（例如，重置后），则清理规则
-      await clearAllDynamicRules();
-    }
+    // 3. 根据状态应用规则
+    await applyLanguageRulesBasedOnState(result.currentLanguage);
 
     // 4. 通知UI更新
-    notifyPopupUIUpdate(isAuto, initialLanguage);
+    const lang = autoSwitchEnabled ? DEFAULT_LANG_EN : (result.currentLanguage || DEFAULT_LANG_EN);
+    notifyPopupUIUpdate(autoSwitchEnabled, lang);
     sendBackgroundLog(backgroundI18n.t('initialization_complete'), 'success');
 
   } catch (error) {
@@ -358,13 +337,43 @@ const initializeState = async (reason) => {
     } catch (cleanupError) {
       sendBackgroundLog(backgroundI18n.t('fallback_state_failed', { message: cleanupError.message }), 'error');
     }
+    throw error; // 向上抛出错误
   }
-}
+};
+
+
+/**
+ * 统一的初始化函数，确保只执行一次
+ * @param {string} reason - 初始化的原因
+ * @returns {Promise<void>}
+ */
+const initialize = (reason) => {
+  if (initializationPromise) {
+    sendBackgroundLog(`Initialization already in progress. Waiting for completion.`, 'info');
+    return initializationPromise;
+  }
+
+  sendBackgroundLog(`Starting initialization with reason: ${reason}`, 'info');
+  initializationPromise = (async () => {
+    try {
+      await performInitialization(reason);
+      isInitialized = true;
+      sendBackgroundLog('Initialization completed successfully.', 'info');
+    } catch (error) {
+      sendBackgroundLog(`Initialization failed: ${error.message}`, 'error');
+      // 在失败时重置，以便可以重试
+      initializationPromise = null;
+      isInitialized = false;
+    }
+  })();
+
+  return initializationPromise;
+};
 
 
 // 当扩展安装或更新时触发
 chrome.runtime.onInstalled.addListener(details => {
-  initializeState(details.reason);
+  initialize(details.reason);
 });
 
 /**
@@ -458,19 +467,16 @@ const handleAutoSwitchToggleRequest = async (request, sendResponse) => {
 
     await chrome.storage.local.set({ autoSwitchEnabled: autoSwitchEnabled });
 
-    // 广播状态变化给所有页面
-    chrome.runtime.sendMessage({
-      type: 'AUTO_SWITCH_STATE_CHANGED',
-      enabled: autoSwitchEnabled
-    }).catch((notifyError) => {
-      sendBackgroundLog(`${backgroundI18n.t('failed_notify_state_change')}: ${notifyError.message}`, 'warning');
-    });
+    const { currentLanguage: storedLanguage } = await chrome.storage.local.get(['currentLanguage']);
+    await applyLanguageRulesBasedOnState(storedLanguage);
 
-    if (autoSwitchEnabled) {
-      await handleAutoSwitchEnabled(sendResponse);
-    } else {
-      await handleAutoSwitchDisabled(sendResponse);
+    const currentEffectiveLanguage = autoSwitchEnabled ? DEFAULT_LANG_EN : (storedLanguage || DEFAULT_LANG_EN);
+
+    if (typeof sendResponse === 'function') {
+      sendResponse({ status: 'success' });
     }
+    notifyPopupUIUpdate(autoSwitchEnabled, currentEffectiveLanguage);
+
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     sendBackgroundLog(`${backgroundI18n.t('auto_switch_toggle_failed')}: ${errorMessage}`, 'error');
@@ -481,40 +487,24 @@ const handleAutoSwitchToggleRequest = async (request, sendResponse) => {
 };
 
 /**
- * 处理自动切换启用
- * @param {Function} sendResponse - 响应函数
+ * 根据当前的自动切换状态应用相应的语言规则
+ * @param {string} storedLanguage - 从存储中读取的语言
  */
-const handleAutoSwitchEnabled = async (sendResponse) => {
-  sendBackgroundLog(backgroundI18n.t('auto_switch_enabled'), 'info');
-  await updateHeaderRules(DEFAULT_LANG_EN, 0, true);
-  if (typeof sendResponse === 'function') {
-    sendResponse({ status: 'success' });
+const applyLanguageRulesBasedOnState = async (storedLanguage) => {
+  let languageToApply;
+  let isAuto = autoSwitchEnabled;
+
+  if (autoSwitchEnabled) {
+    languageToApply = DEFAULT_LANG_EN;
+    sendBackgroundLog(backgroundI18n.t('auto_switch_enabled_applying_rules', { language: languageToApply }), 'info');
+  } else {
+    languageToApply = storedLanguage || DEFAULT_LANG_EN;
+    sendBackgroundLog(backgroundI18n.t('auto_switch_disabled_applying_rules', { language: languageToApply }), 'info');
   }
-  notifyPopupUIUpdate(true, DEFAULT_LANG_EN);
+  
+  await updateHeaderRules(languageToApply, 0, isAuto);
 };
 
-/**
- * 处理自动切换禁用
- * @param {Function} sendResponse - 响应函数
- */
-const handleAutoSwitchDisabled = async (sendResponse) => {
-  const result = await new Promise((resolve, reject) => {
-    chrome.storage.local.get(['currentLanguage'], (result) => {
-      if (chrome.runtime.lastError) {
-        reject(new Error(chrome.runtime.lastError.message));
-        return;
-      }
-      resolve(result);
-    });
-  });
-  const language = result.currentLanguage || DEFAULT_LANG_EN;
-  sendBackgroundLog(backgroundI18n.t('auto_switch_disabled', { language }), 'info');
-  await updateHeaderRules(language);
-  if (typeof sendResponse === 'function') {
-    sendResponse({ status: 'success' });
-  }
-  notifyPopupUIUpdate(false, language);
-};
 
 /**
  * 处理获取当前语言请求
@@ -948,123 +938,84 @@ const handleUpdateCheckError = (error, sendResponse) => {
 
 // 监听来自 popup 或 debug 页面的消息
 chrome.runtime.onMessage.addListener((request, _, sendResponse) => {
-  if (request.type === 'UPDATE_RULES') {
-    handleUpdateRulesRequest(request, sendResponse);
-    return true;
-  } else if (request.type === 'AUTO_SWITCH_TOGGLED') {
-    handleAutoSwitchToggleRequest(request, sendResponse);
-    return true;
-  } else if (request.type === 'GET_CURRENT_LANG') {
-    handleGetCurrentLangRequest(sendResponse);
-    return true;
-  } else if (request.type === 'RESET_ACCEPT_LANGUAGE') {
-    handleResetAcceptLanguageRequest(sendResponse);
-    return true;
-  } else if (request.type === 'GET_DOMAIN_RULES') {
-    handleGetDomainRulesRequest(sendResponse);
-    return true;
-  } else if (request.type === 'UPDATE_CHECK') {
-    handleUpdateCheckRequest(sendResponse);
-    return true;
-  } else if (request.type === 'GET_CACHE_STATS') {
-    handleGetCacheStatsRequest(sendResponse);
-    return true;
-  } else if (request.type === 'TEST_DOMAIN_CACHE') {
-    handleTestDomainCacheRequest(request, sendResponse);
-    return true;
-  } else if (request.type === 'PRELOAD_RULES') {
-    handlePreloadRulesRequest(sendResponse);
-    return true;
-  } else if (request.type === 'CLEAR_DOMAIN_CACHE') {
-    handleClearDomainCacheRequest(sendResponse);
-    return true;
-  } else if (request.type === 'CLEAR_ALL_CACHE') {
-    handleClearAllCacheRequest(sendResponse);
-    return true;
-  } else if (request.type === 'RESET_CACHE_STATS') {
-    handleResetCacheStatsRequest(sendResponse);
-    return true;
-  } else if (request.type === 'GET_DYNAMIC_RULES') {
-    handleGetDynamicRulesRequest(sendResponse);
-    return true;
-  } else if (request.type === 'GET_MATCHED_RULES') {
-    handleGetMatchedRulesRequest(sendResponse);
-    return true;
-  } else if (request.type === 'UPDATE_DYNAMIC_RULES') {
-    handleUpdateDynamicRulesRequest(request, sendResponse);
-    return true;
-  } else if (request.type === 'GET_STORAGE_DATA') {
-    handleGetStorageDataRequest(request, sendResponse);
-    return true;
-  } else if (request.type === 'SET_STORAGE_DATA') {
-    handleSetStorageDataRequest(request, sendResponse);
-    return true;
-  } else if (request.type === 'GET_MANIFEST_INFO') {
-    handleGetManifestInfoRequest(sendResponse);
-    return true;
-  }
+  (async () => {
+    await ensureInitialized();
+    if (request.type === 'UPDATE_RULES') {
+      handleUpdateRulesRequest(request, sendResponse);
+    } else if (request.type === 'AUTO_SWITCH_TOGGLED') {
+      handleAutoSwitchToggleRequest(request, sendResponse);
+    } else if (request.type === 'GET_CURRENT_LANG') {
+      handleGetCurrentLangRequest(sendResponse);
+    } else if (request.type === 'RESET_ACCEPT_LANGUAGE') {
+      handleResetAcceptLanguageRequest(sendResponse);
+    } else if (request.type === 'GET_DOMAIN_RULES') {
+      handleGetDomainRulesRequest(sendResponse);
+    } else if (request.type === 'UPDATE_CHECK') {
+      handleUpdateCheckRequest(sendResponse);
+    } else if (request.type === 'GET_CACHE_STATS') {
+      handleGetCacheStatsRequest(sendResponse);
+    } else if (request.type === 'TEST_DOMAIN_CACHE') {
+      handleTestDomainCacheRequest(request, sendResponse);
+    } else if (request.type === 'PRELOAD_RULES') {
+      handlePreloadRulesRequest(sendResponse);
+    } else if (request.type === 'CLEAR_DOMAIN_CACHE') {
+      handleClearDomainCacheRequest(sendResponse);
+    } else if (request.type === 'CLEAR_ALL_CACHE') {
+      handleClearAllCacheRequest(sendResponse);
+    } else if (request.type === 'RESET_CACHE_STATS') {
+      handleResetCacheStatsRequest(sendResponse);
+    } else if (request.type === 'GET_DYNAMIC_RULES') {
+      handleGetDynamicRulesRequest(sendResponse);
+    } else if (request.type === 'GET_MATCHED_RULES') {
+      handleGetMatchedRulesRequest(sendResponse);
+    } else if (request.type === 'UPDATE_DYNAMIC_RULES') {
+      handleUpdateDynamicRulesRequest(request, sendResponse);
+    } else if (request.type === 'GET_STORAGE_DATA') {
+      handleGetStorageDataRequest(request, sendResponse);
+    } else if (request.type === 'SET_STORAGE_DATA') {
+      handleSetStorageDataRequest(request, sendResponse);
+    } else if (request.type === 'GET_MANIFEST_INFO') {
+      handleGetManifestInfoRequest(sendResponse);
+    }
+  })();
+  return true;
 });
 
 // 监听标签页更新以实现自动切换 (Manifest V3 compatible)
-chrome.tabs.onUpdated.addListener(async (_, changeInfo, tab) => {
-  // 调试日志：记录所有相关事件
-  if (changeInfo.status === 'complete' && tab?.url?.startsWith('http')) {
-    sendBackgroundLog(backgroundI18n.t('tab_update_debug', { url: tab.url, autoSwitch: autoSwitchEnabled }), 'info');
-  }
+chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
+  await ensureInitialized();
 
-  // 确保自动切换已启用，标签页加载完成，并且有有效的URL (http or https)
   if (autoSwitchEnabled && changeInfo.status === 'complete' && tab?.url?.startsWith('http')) {
-    sendBackgroundLog(`${backgroundI18n.t('tab_updated')}: ${tab.url}, ${backgroundI18n.t('status')}: ${changeInfo.status}`, 'info');
     try {
       const url = new URL(tab.url);
-      const currentHostname = url.hostname.toLowerCase();
-      let targetLanguage = null;
-
-      // 使用域名规则管理器获取语言
-      sendBackgroundLog(backgroundI18n.t('finding_language_rule', { hostname: currentHostname }), 'info');
-      targetLanguage = await getLanguageForDomain(currentHostname);
-      if (targetLanguage) {
-        sendBackgroundLog(backgroundI18n.t('domain_rule_match_success', { hostname: currentHostname, language: targetLanguage }), 'success');
-      }
+      const hostname = url.hostname.toLowerCase();
+      
+      const targetLanguage = await getLanguageForDomain(hostname);
 
       if (targetLanguage) {
-        sendBackgroundLog(backgroundI18n.t('auto_switching_hostname', { hostname: currentHostname, language: targetLanguage }), 'info');
-        // 调用 updateHeaderRules 更新请求头，标记为自动切换 (isAutoSwitch = true)
-        try {
-          const result = await updateHeaderRules(targetLanguage, 0, true);
-          sendBackgroundLog(backgroundI18n.t('auto_switch_success', { hostname: currentHostname, language: targetLanguage, status: result.status }), 'success');
-          if (result.status === 'success') {
-            notifyPopupUIUpdate(true, targetLanguage);
-          }
-        } catch (error) {
-          sendBackgroundLog(`${backgroundI18n.t('auto_switch_failed', { hostname: currentHostname, language: targetLanguage })}: ${error.message}`, 'error');
+        // 如果找到特定于域的语言，则应用它
+        sendBackgroundLog(backgroundI18n.t('auto_switching_hostname', { hostname, language: targetLanguage }), 'info');
+        const result = await updateHeaderRules(targetLanguage, 0, true);
+        if (result.status === 'success') {
+          notifyPopupUIUpdate(true, targetLanguage);
         }
       } else {
-        // 如果没有匹配的规则，使用回退语言
+        // 否则，确保应用了默认的回退语言
         const fallbackLanguage = DEFAULT_LANG_EN;
-        sendBackgroundLog(backgroundI18n.t('no_matching_rule', { hostname: currentHostname, fallback: fallbackLanguage }), 'info');
-        // 只有在当前语言不是回退语言时才更新
-        try {
-          const rules = await chrome.declarativeNetRequest.getDynamicRules();
-          const currentRule = rules.find(rule => rule.id === RULE_ID);
-          const currentLang = currentRule?.action?.requestHeaders?.find(h => h.header === 'Accept-Language')?.value;
+        const rules = await chrome.declarativeNetRequest.getDynamicRules();
+        const currentRule = rules.find(rule => rule.id === RULE_ID);
+        const currentLang = currentRule?.action?.requestHeaders?.find(h => h.header === 'Accept-Language')?.value;
 
-          if (currentLang !== fallbackLanguage) {
-            const result = await updateHeaderRules(fallbackLanguage, 0, true);
-            sendBackgroundLog(backgroundI18n.t('fallback_language_applied', { hostname: currentHostname, fallback: fallbackLanguage, status: result.status }), 'info');
-            if (result.status === 'success') {
-              notifyPopupUIUpdate(true, fallbackLanguage);
-            }
-          } else {
-            sendBackgroundLog(backgroundI18n.t('current_is_fallback', { fallback: fallbackLanguage }), 'info');
+        if (currentLang !== fallbackLanguage) {
+          sendBackgroundLog(backgroundI18n.t('no_matching_rule', { hostname, fallback: fallbackLanguage }), 'info');
+          const result = await updateHeaderRules(fallbackLanguage, 0, true);
+          if (result.status === 'success') {
+            notifyPopupUIUpdate(true, fallbackLanguage);
           }
-        } catch (error) {
-          sendBackgroundLog(`${backgroundI18n.t('fallback_language_failed', { hostname: currentHostname })}: ${error.message}`, 'error');
         }
       }
-    } catch (e) {
-      // 捕获并记录解析URL或处理过程中可能发生的任何错误
-      sendBackgroundLog(`${backgroundI18n.t('error_processing_url', { url: tab.url })}: ${e.message}`, 'error');
+    } catch (error) {
+      sendBackgroundLog(`${backgroundI18n.t('error_processing_url', { url: tab.url })}: ${error.message}`, 'error');
     }
   }
 });

--- a/docs/Problems.md
+++ b/docs/Problems.md
@@ -1,27 +1,18 @@
-1. Service Worker 生命周期与初始化一致性
-
-- 现状：
-  - chrome.runtime.onStartup 调用 initializeState('startup')，但 chrome.runtime.onInstalled 仅调用 initDomainRulesManager，未统一走初始化路径；SW 重启后也未有统一恢复逻辑（SW 会被回收，global 状态如 autoSwitchEnabled、lastAppliedLanguage、缓存会丢失）。
-- 风险：自动切换功能在 SW 重启后可能处于“未初始化但默认关闭”的非预期状态；规则、语言状态恢复不一致。
-- 建议：
-  - 在 onInstalled 中也调用 initializeState('installed'|'updated')（或拆分一个统一的 `bootstrap()` 顶层入口，SW 启动时执行）。
-  - 在消息入口或 tabs 监听中加入“懒初始化守卫”（例如检测一个 initialized 标志，未初始化时触发一次 initializeState('lazy')）。
-
-2. 动态规则清理范围过宽
+1. 动态规则清理范围过宽
 
 - 现状：
   - updateHeaderRules 使用 removeRuleIds = existingRules.map(rule => rule.id) 清理“本扩展”所有动态规则，而不仅是用于 Accept-Language 的 RULE_ID。
 - 风险：未来若本扩展添加其他动态规则，会被误删，导致功能相互踩踏。
 - 建议：仅移除与 RULE_ID 相关的旧规则；不要全量移除本扩展的所有动态规则。
 
-3. 并发与竞态问题（缺少互斥/队列）
+2. 并发与竞态问题（缺少互斥/队列）
 
 - 现状：
   - updateHeaderRules 可被 popup 和自动切换并发触发；未见锁/队列；rulesCache 仅用于“非自动切换”时的早退，且并不能避免并发 DNR 更新。
 - 风险：并发更新可能导致重复 get/set 规则、状态抖动或日志噪声。
 - 建议：为 updateHeaderRules 引入简单互斥（Promise 队列/信号量），或合并短时间内的重复请求；对相同语言的重复调用直接短路返回（自动切换也可安全短路，因为规则仅由本扩展管理）。
 
-4. 初始化/存储 API 使用不一致
+3. 初始化/存储 API 使用不一致
 
 - 现状：
   - 代码中混用 Promise 风格 await chrome.storage.local.get(['key']) 与基于回调的 new Promise((resolve) => chrome.storage.local.get(...))。
@@ -30,13 +21,13 @@
 
 中优先级问题与建议 
 
-5. 自动切换时的无效更新与性能浪费
+4. 自动切换时的无效更新与性能浪费
 
 - 现状：
   - 自动切换路径即使当前语言与目标相同，也会调用 updateHeaderRules 再走一遍 getDynamicRules 检查，最后返回“unchanged”。这在频繁 tab 更新时浪费一次 API 调用。
 - 建议：若 lastAppliedLanguage === targetLanguage 则直接早退（自动切换也可安全早退）。如担心外部修改，可以增加“低频校验”。
 
-6. DNR 资源类型与匹配范围
+5. DNR 资源类型与匹配范围
 
 - 现状：
   - 规则 `condition.urlFilter: "*"`，`resourceTypes` 包含大量类型。
@@ -46,55 +37,55 @@
   - 收窄 `resourceTypes` 至会携带 Accept-Language 的类型：`main_frame`, `sub_frame`, `xmlhttprequest`（基本可覆盖 fetch/XHR），如需谨慎可保留 script/`image` 等是否冗余评估。
   - 如果能接受仅针对 http/https，可通过 `regexFilter` 或规则集合减少歧义（可选）。
 
-7. SW 日志与 i18n 加载顺序
+6. SW 日志与 i18n 加载顺序
 
 - 现状：
   - DomainRulesManager 依赖全局 domainManagerI18n，注释称 shared-i18n-base.js 已在 background.js 通过 importScripts 加载（未在审查片段中直接看到）。
 - 风险：若加载顺序变更或未来重构为 ESM，可能造成 i18n 未就绪。
 - 建议：在 background.js 顶部保证导入顺序：shared-i18n-base.js -> i18n/*-i18n.js -> 其他模块；或在 DomainRulesManager 内对 i18n 缺失做好降级处理（已有，但建议保证顺序）。
 
-8. 域名规则加载的健壮性
+7. 域名规则加载的健壮性
 
 - 现状：
   - domain-rules.json 使用 fetch(getURL(..))，无超时/重试；失败时返回空规则。
 - 建议：
   - 为规则文件加载增加超时与有限重试；失败时可设置“只使用 TLD 兜底”或“直接走 fallback 语言，不自动切换”策略，避免误判。
 
-9. 自定义规则变更的缓存失效
+8. 自定义规则变更的缓存失效
 
 - 现状：
   - 存在自定义规则加载逻辑与缓存（domainCache、parsedDomainCache），但未见“自定义规则更新后自动清理/失效缓存”的路径。
 - 建议：
   - 在写入/修改自定义规则后调用 clearCache(true) 或精细化失效，避免旧缓存导致匹配不生效。
 
-10. 更新检查与网络权限
+9. 更新检查与网络权限
 
 - 现状：
   - UpdateChecker 针对 GitHub Releases 有完善的超时/重试/降级；但对 host_permissions 声明不明（MV3 中 extension pages 跨域 fetch 通常允许，但建议最小权限）。
 - 建议：
   - 若 manifest 中启用了 `host_permissions: ["https://api.github.com/*"]`，请确认最小化；若未声明但能正常工作，可在文档中注明“无需 host_permissions”。
 
-低优先级/可读性与维护性 11) 消息处理 return true 一致性
+低优先级/可读性与维护性 10) 消息处理 return true 一致性
 
 - 现状：
   
   - onMessage 的分支大多 `return true` 以保持异步响应。请确保新增消息类型也保持一致，避免响应丢失。
 
-12. 命名与常量集中
+11. 命名与常量集中
   
 
 - 建议：
   
   - 将 RULE_ID、默认语言（DEFAULT_LANG_EN, DEFAULT_LANG_ZH）、重试常量、缓存大小等集中到 `shared/constants.js`，便于统一修改。
 
-13. 统一日志接口
+12. 统一日志接口
   
 
 - 建议：
   
   - sendBackgroundLog 很好用；建议统一所有 console.log/warn/error 入口（尤其 Service Worker 侧），便于开关调试等级与搜集问题。
 
-14. 文档与注释
+13. 文档与注释
   
 
 - 建议：
@@ -104,7 +95,6 @@ MV3 合规检查（重点项）
 
 - Service Worker：
   - 无长轮询/持久计时器；消息处理 return true；OK。
-  - 生命周期恢复需加强（见问题 1）。
 - 权限：
   - 使用 declarativeNetRequest（已在 debug 检查中校验），如果使用了 `declarativeNetRequestFeedback` 需确认是否实际使用，否则移除。
   - 读取 tab.url 需 tabs 权限或相应 host 权限；核对 manifest.json 是否已声明。
@@ -115,14 +105,14 @@ MV3 合规检查（重点项）
 - messaging：
   - onMessage 使用模式正确；异步返回已 return true；OK。
 - DNR 规则：
-  - `modifyHeaders` 使用动态规则；OK。建议收窄资源类型（见问题 6）。
+  - `modifyHeaders` 使用动态规则；OK。建议收窄资源类型（见问题 5）。
 
 缓存正确性与性能
 
 - LRU 实现正确（基于 Map 插入顺序；重复键先删后设；满容量淘汰首个）。
 - maxCacheSize=100 保守，合理。可考虑曝光为设置或根据内存占用自适应。
 - 命中率统计简洁；考虑在日志中周期性输出以便调优。
-- 中枢路径上尽量减少 getDynamicRules 调用频率（见问题 5）。
+- 中枢路径上尽量减少 getDynamicRules 调用频率（见问题 4）。
 
 i18n 与回退
 
@@ -147,7 +137,6 @@ i18n 与回退
 
 可操作修复清单（按优先级）
 
-- onInstalled 走与 onStartup 一致的初始化流，或统一顶层 `bootstrap()`。
 - 限定 DNR 清理与更新仅作用于 RULE_ID；不要全清本扩展的动态规则。
 - 为 updateHeaderRules 增加互斥/队列；对相同语言更新进行短路（自动切换同样短路）。
 - 统一 chrome.storage Promise 风格；封装读写方法。

--- a/docs/Project_Structure.md
+++ b/docs/Project_Structure.md
@@ -9,7 +9,7 @@ MultiLangSwitcher/
 │   └── zh/                          - 中文语言包
 ├── docs/                            - 项目文档目录
 │   ├── README/                      - 多语言说明文档目录
-│   ├── Wiki.md                      - 开发者 Wiki（项目核心架构和技术规范）
+│   ├── Wiki/                        - 开发者 Wiki（项目核心架构和技术规范）
 │   ├── Code_Style_Guide.md          - 代码风格指南（详细的代码规范和最佳实践）
 │   ├── Project_Structure.md         - 项目结构文档（完整的文件结构说明）
 │   ├── I18n_Usage_Guide.md          - 国际化使用指南（国际化系统的使用方法）

--- a/docs/Update.md
+++ b/docs/Update.md
@@ -5,12 +5,15 @@
 ### 1. 功能增强
 
 - ✅ 菜单功能完善 - 添加浏览器拓展右键菜单
+- ✅ 重构 Service Worker 初始化逻辑：
+  - **统一初始化入口**：创建了单一的 `initialize` 函数，用于处理扩展安装、浏览器启动和 Service Worker 意外重启时的状态恢复，确保了逻辑的一致性。
+  - **实现懒加载守卫**：引入 `ensureInitialized` 机制，在处理 `onMessage`、`onUpdated` 等事件前检查并确保初始化已完成，有效防止了因 Service Worker 休眠后重启导致的状态丢失问题。
 
 ### 2. 代码优化
 
 - ✅ 清理无效代码 - 去除无效变量 err
 - ✅ 重构 createContextMenusOnce 使用 async/await（Promise API），符合代码规范
-- ✅ 右键菜单项统一使用英文，去除 i18n 化（简化实现）
+- ✅ 右键菜单统一使用英文，去除 i18n 化（简化实现）
 - ✅ 简化URL检查条件
 
 ### 3. Bug 修复
@@ -29,16 +32,17 @@
 
 ### 修改文件
 
-- manifest.json - 版本号更新（v1.8.67、v1.8.68）；添加 contextMenus 权限（v1.8.67）
+- manifest.json - 版本号更新（v1.8.67、v1.8.68、v1.8.69）；添加 contextMenus 权限（v1.8.67）
 - TODO.md - 修改待办事项（v1.8.67）
-- Update.md - 版本更新记录（v1.8.67、v1.8.68）
-- background.js - 添加右键菜单初始化标志（v1.8.67）；重构 contextMenus 创建逻辑（async/await），右键菜单统一使用英文，去除 i18n 化（v1.8.68）；修复 `tabs.onUpdated` 的 URL 过滤条件 Bug（v1.8.68）；简化URL检查条件（v1.8.68）
+- Update.md - 版本更新记录（v1.8.67、v1.8.68、v1.8.69）
+- background.js - 添加右键菜单初始化标志（v1.8.67）；重构 contextMenus 创建逻辑（async/await），右键菜单统一使用英文，去除 i18n 化（v1.8.68）；修复 `tabs.onUpdated` 的 URL 过滤条件 Bug（v1.8.68）；简化URL检查条件（v1.8.68）；重构了初始化和事件处理逻辑（v1.8.69）
 - shared/shared-i18n-base.js - 优化翻译加载机制，避免重复加载脚本文件，完善翻译回退（v1.8.68）
 - I18n_Usage_Guide.md - 内容更新（v1.8.67、v1.8.68）
 - .gitignore - git忽略文件更新（v1.8.67）
-- Problems.md - 问题列表更新（v1.8.68）
+- Problems.md - 问题列表更新（v1.8.68、v1.8.69）
 
 ### 移除内容
 
 - 移除未使用的变量 chrome.runtime.lastError 读取语句
 - 已完成的TODO / 已修复的问题
+- 将 `performInitialization` 和 `handleAutoSwitchToggleRequest` 中的重复规则应用逻辑提取到新的共享函数 `applyLanguageRulesBasedOnState` 中

--- a/docs/Update.md
+++ b/docs/Update.md
@@ -25,6 +25,7 @@
 ### 新增文件
 
 - Problems.md - LLM整理的现存问题（v1.8.67）
+- Wiki_EN.md - 英文版Wiki（v1.8.69）
 
 ### 重命名文件
 
@@ -36,10 +37,11 @@
 - TODO.md - 修改待办事项（v1.8.67）
 - Update.md - 版本更新记录（v1.8.67、v1.8.68、v1.8.69）
 - background.js - 添加右键菜单初始化标志（v1.8.67）；重构 contextMenus 创建逻辑（async/await），右键菜单统一使用英文，去除 i18n 化（v1.8.68）；修复 `tabs.onUpdated` 的 URL 过滤条件 Bug（v1.8.68）；简化URL检查条件（v1.8.68）；重构了初始化和事件处理逻辑（v1.8.69）
-- shared/shared-i18n-base.js - 优化翻译加载机制，避免重复加载脚本文件，完善翻译回退（v1.8.68）
+- shared-i18n-base.js - 优化翻译加载机制，避免重复加载脚本文件，完善翻译回退（v1.8.68）
 - I18n_Usage_Guide.md - 内容更新（v1.8.67、v1.8.68）
 - .gitignore - git忽略文件更新（v1.8.67）
 - Problems.md - 问题列表更新（v1.8.68、v1.8.69）
+- Wiki.md - Wiki更新（v1.8.69）
 
 ### 移除内容
 

--- a/docs/Wiki/Wiki_EN.md
+++ b/docs/Wiki/Wiki_EN.md
@@ -1,0 +1,291 @@
+# MultiLangSwitcher Developer Wiki
+
+## Overview
+
+MultiLangSwitcher is a Chrome extension based on Manifest V3 that switches website languages by dynamically modifying the `Accept-Language` HTTP request header. This Wiki integrates the project's core architecture, technical specifications, and development guidelines.
+
+## Table of Contents
+
+- [Product Overview](#product-overview)
+- [Core Architecture](#core-architecture)
+- [Technology Stack](#technology-stack)
+- [Project Structure](#project-structure)
+- [Code Style Guide](#code-style-guide)
+- [Development Guide](#development-guide)
+- [Performance Requirements](#performance-requirements)
+- [Related Documents](#related-documents)
+
+## Product Overview
+
+### Core Features
+- **Manual Language Selection**: Switch languages through the popup interface.
+- **Custom Language Header**: Supports custom `Accept-Language` request header strings.
+- **Automatic Domain Switching**: Automatic language matching based on TLD and second-level domains.
+- **Real-time Header Verification**: Real-time request header verification via `detect.html`.
+- **English Fallback Mechanism**: Defaults to English for unmatched domains.
+
+### Design Principles
+- Uses the latest Manifest V3 standard.
+- Pure JavaScript/HTML/CSS implementation, no build system.
+- Modular architecture with high code reusability.
+- Full internationalization support.
+- Robust error handling and fallback mechanisms.
+
+## Core Architecture
+
+### Service Worker Model
+
+```
+background.js (Central Service Worker)
+├── Manages all extension logic
+├── Exclusively manages declarativeNetRequest rules
+├── Implements exponential backoff retry mechanism
+└── Handles domain-based automatic switching
+```
+
+**Key Requirements:**
+- `background.js` is the only service worker.
+- Must exclusively manage `declarativeNetRequest` rules.
+- Must implement a messaging mechanism.
+- Must handle tab monitoring and automatic switching.
+
+### Service Worker Initialization and State Management
+
+To handle the fact that a Service Worker can go dormant and restart at any time in Manifest V3, the project uses a robust initialization and state management mechanism to ensure the extension runs correctly at all times.
+
+**Core Principles:**
+- **Unified Initialization Entry Point**: All logic related to state restoration (e.g., extension installation, browser startup, unexpected Service Worker restart) is handled by a single `initialize` function to ensure consistent behavior.
+- **Lazy Loading and Event-Driven**: Initialization is not performed immediately when the script loads, but is triggered by a guard function `ensureInitialized` the first time state needs to be accessed or a critical event is handled (e.g., `onMessage`, `onUpdated`). This avoids unnecessary upfront work and ensures that the state is ready before any operation is performed.
+- **Idempotency**: The initialization process is idempotent. Even if called multiple times, it will only execute effectively once, preventing duplicate operations and state conflicts.
+
+**Implementation Pattern:**
+```javascript
+// background.js
+
+// Global initialization Promise to prevent duplicate execution
+let initializationPromise = null;
+// State flag indicating if initialization is complete
+let isInitialized = false;
+
+// Guard function: call before performing any operation that requires state
+const ensureInitialized = async () => {
+ if (!isInitialized) {
+   await initialize('lazy'); // Trigger if not initialized
+ }
+};
+
+// Unified initialization function
+const initialize = (reason) => {
+ if (initializationPromise) {
+   return initializationPromise; // Return existing Promise if in progress
+ }
+ 
+ initializationPromise = (async () => {
+   // ...execute all initialization logic...
+   isInitialized = true; // Mark as complete
+ })();
+ 
+ return initializationPromise;
+};
+
+// Apply the guard in event listeners
+chrome.runtime.onMessage.addListener((request, _, sendResponse) => {
+ (async () => {
+   await ensureInitialized(); // ✅ Ensure state is ready
+   // ...handle message...
+ })();
+ return true;
+});
+```
+
+### Component Architecture
+
+```
+MultiLangSwitcher/
+├── root/                       # Main extension files
+│   ├── popup.js              # Popup UI logic
+│   ├── debug-ui.js           # Debug UI logic
+│   └── background.js         # Background Service Worker
+├── /shared/                  # Shared utility library (must be used)
+│   ├── shared-utils.js       # Logging, language detection, fallback translation system
+│   ├── shared-actions.js     # Message passing constants
+│   ├── shared-language-options.js  # Language options utility
+│   ├── shared-update-checker.js    # Update check functionality
+│   └── shared-i18n-base.js   # Base internationalization functionality
+├── /i18n/                    # Internationalization system
+│   ├── {component}-{lang}.js # Translation files
+│   └── {component}-i18n.js   # Internationalization class definitions
+└── domain-rules-manager.js   # Domain rules management
+```
+
+## Technology Stack
+
+### Required Technologies
+- **Manifest V3**: Latest manifest version for Chrome extensions.
+- **JavaScript**: ES6+ syntax, external frameworks disabled.
+- **Bootstrap 5**: Use existing `bootstrap.min.css` for UI styling.
+- **Chrome Extension APIs**:
+  - `declarativeNetRequest` - The only method for modifying request headers.
+  - `storage.local` - Settings persistence.
+  - `tabs` - Tab monitoring for automatic switching.
+  - `runtime` - Inter-component message passing.
+
+### Architectural Patterns
+
+#### Fallback Translation System
+```
+Translation Priority:
+1. Primary: Component-specific i18n instances (popupI18n, backgroundI18n, etc.)
+2. Secondary: Cross-component translation objects (popupEn, backgroundZh, etc.)
+3. Tertiary: Built-in fallback translations in shared-utils.js
+4. Auto-detection: Browser language → localStorage → Fallback to English
+```
+
+**Key Functions:**
+- `getFallbackTranslation()` - Gets fallback translation.
+- `getUpdateTranslation()` - Gets update-related translations.
+- `sendLocalizedUpdateLog()` - Sends localized debug logs.
+
+#### Message Passing
+- Must use `chrome.runtime.sendMessage` for background ↔ UI communication.
+- Implement event-driven inter-component updates.
+- Must debounce UI updates.
+
+#### Storage Management
+- Must persist settings via `chrome.storage.local`.
+- Store domain rules in `domain-rules.json`, supporting runtime customization.
+- Cache custom rules in browser storage for performance.
+
+## Project Structure
+
+For a detailed project structure, please refer to: [Project Structure Document](./Project_Structure.md)
+
+### File Naming Conventions (Mandatory)
+
+#### JavaScript Files
+- **UI Components**: `{page}.js` (popup.js, debug-ui.js)
+- **Shared Modules**: `shared-*.js` prefix
+- **Managers**: `*-manager.js` suffix
+- **Internationalization Files**: `{component}-{lang}.js` and `{component}-i18n.js`
+
+#### HTML Files
+- **Extension Pages**: `{function}.html` (popup.html, debug.html)
+- **Test Tools**: `test-*.html` prefix
+
+## Code Style Guide
+
+For a detailed code style guide, please refer to: [Code Style Guide](./Code_Style_Guide.md)
+
+### JavaScript Requirements
+- **ES6+ Features**: async/await, arrow functions, destructuring, template literals.
+- **Variable Declarations**: Use `const`/`let` - do not use `var`.
+- **Asynchronous Operations**: Wrap all async operations in try/catch blocks.
+- **Module Imports**: Import shared utilities from the `/shared/` directory.
+
+### Error Handling
+- **Unified Error Handling Pattern**: Use an early return pattern to avoid deeply nested if-else chains.
+- **Exponential Backoff Retry Mechanism**: Implement smart retries for all Chrome API calls, including error classification and retry decisions.
+- **Modular Retry Logic**: Split complex retry logic into dedicated helper methods to improve maintainability.
+- **Avoid Duplicate Handling**: Ensure the same error is handled only once to avoid redundant calls to error handlers and improve performance.
+- **Error Enhancement Mechanism**: Provide detailed error information and fallback suggestions for final failures.
+- **Debug Logging**: Log all errors using the `sendDebugLog()` function from shared utilities.
+- **Graceful Fallback Solutions**: Provide user-friendly fallback mechanisms for failed operations.
+- **User-Friendly Hints**: Display clear error messages and resolution suggestions in UI components.
+
+### Component Creation Rules
+1. Place the main file in the root directory.
+2. Create corresponding internationalization files in `/i18n/`.
+3. Always import shared utilities from `/shared/` - no duplicate code.
+4. Strictly follow the established naming conventions.
+
+## Development Guide
+
+### Development Workflow
+- **Pure Tech Stack**: JavaScript/HTML/CSS, no build system.
+- **Development Testing**: Load as an unpacked extension for development.
+- **Request Header Verification**: Use `detect.html` for real-time verification.
+- **Rule Checking**: Use `debug.html` for rule checking and troubleshooting.
+
+### Testing Strategy
+- Test domain switching with multiple tabs.
+- Test various TLD patterns.
+- Verify automatic switching and manual selection features.
+- Test error handling and fallback mechanisms.
+
+## Performance Requirements
+
+### Background Script Optimization
+- Minimize background script execution time and memory usage.
+- Use efficient domain matching algorithms (avoid regex where possible).
+- Batch process `declarativeNetRequest` rule updates.
+- Cache domain rules in memory for fast lookups.
+
+#### Domain Matching Algorithm
+The project implements an efficient domain matching algorithm that supports multiple matching patterns and intelligent language recognition, providing core support for the "Auto-Switch Language" feature.
+
+**Algorithm Architecture:**
+- **Multi-layer Matching Strategy**: Full domain match, language subdomain recognition, second-level domain match, TLD match.
+- **Cache System**: Domain query cache and resolution cache, using an LRU strategy to manage memory.
+- **Rule Preprocessing**: Group rules by type at startup to improve lookup efficiency.
+
+**Core Features:**
+- **Traditional Domain Matching**: Language recognition based on TLD and second-level domains.
+- **Modern Website Support**: Recognizes language subdomain patterns like `cn.bing.com`, `zh-hans.react.dev`.
+- **Intelligent Inference**: Infers language code from language subdomains when a rule match fails.
+- **Performance Optimization**: Multi-layer caching mechanism significantly improves performance for repeated queries.
+
+**Usage Example:**
+```javascript
+// Basic domain language recognition
+const language = await domainRulesManager.getLanguageForDomain('example.com');
+
+// Supported matching patterns
+'baidu.com' → 'zh-CN'        // Full domain match
+'cn.bing.com' → 'zh-CN'      // Language subdomain recognition
+'google.co.jp' → 'ja'        // Second-level domain match
+'example.de' → 'de-DE'       // TLD match
+
+// Management functions
+await domainRulesManager.preloadRules(); // Preload rules
+domainRulesManager.getCacheStats();      // Cache statistics
+domainRulesManager.clearCache();         // Clear cache
+```
+
+For more details, please refer to: [Domain Matching Guide](./Domain_Matching_Guide.md)
+
+### UI Performance
+- Debounce UI updates to prevent excessive re-rendering.
+- Batch DOM operations.
+- Use event delegation to reduce the number of event listeners.
+
+## Related Documents
+
+### Core Documents
+- [Code Style Guide](./Code_Style_Guide.md) - Detailed code specifications and best practices.
+- [Project Structure Document](./Project_Structure.md) - Complete project file structure explanation.
+- [I18n Usage Guide](./I18n_Usage_Guide.md) - How to use the internationalization system.
+
+### Development Documents
+- [Update Log](./Update.md) - Version update records.
+- [TODO List](./TODO.md) - To-be-completed features and improvement items.
+
+### GitHub Repository
+- Project Address: https://github.com/ChuwuYo/MultiLangSwitcher
+
+## Contribution Guide
+
+### Pre-development Preparation
+1. Read this Wiki and related documents.
+2. Understand the Chrome Extension Manifest V3 specification.
+3. Familiarize yourself with the project's code style and architectural patterns.
+
+### Code Submission Guidelines
+1. Follow the project's code style guide.
+2. Ensure all new features have corresponding error handling.
+3. Add appropriate debug logs and comments.
+4. Test feature behavior in different scenarios.
+
+### Issue Reporting
+- Use `debug.html` to collect debug information.
+- Provide detailed steps to reproduce.
+- Include browser version and extension version information.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "MultiLangSwitcher",
-  "version": "1.8.68",
+  "version": "1.8.69",
   "minimum_chrome_version": "88.0",
   "description": "__MSG_extension_description__",
   "default_locale": "zh",


### PR DESCRIPTION
# v1.8.68（含迭代内容）

## 主要改动

### 1. 功能增强

- ✅ 菜单功能完善 - 添加浏览器拓展右键菜单
- ✅ 重构 Service Worker 初始化逻辑：
  - **统一初始化入口**：创建了单一的 `initialize` 函数，用于处理扩展安装、浏览器启动和 Service Worker 意外重启时的状态恢复，确保了逻辑的一致性。
  - **实现懒加载守卫**：引入 `ensureInitialized` 机制，在处理 `onMessage`、`onUpdated` 等事件前检查并确保初始化已完成，有效防止了因 Service Worker 休眠后重启导致的状态丢失问题。

### 2. 代码优化

- ✅ 清理无效代码 - 去除无效变量 err
- ✅ 重构 createContextMenusOnce 使用 async/await（Promise API），符合代码规范
- ✅ 右键菜单统一使用英文，去除 i18n 化（简化实现）
- ✅ 简化URL检查条件

### 3. Bug 修复

- ✅ 修复 `tabs.onUpdated` 过滤条件 Bug，该 Bug 会导致 http 页面不触发自动切换

## 文件变更清单

### 新增文件

- Problems.md - LLM整理的现存问题（v1.8.67）
- Wiki_EN.md - 英文版Wiki（v1.8.69）

### 重命名文件

- 

### 修改文件

- manifest.json - 版本号更新（v1.8.67、v1.8.68、v1.8.69）；添加 contextMenus 权限（v1.8.67）
- TODO.md - 修改待办事项（v1.8.67）
- Update.md - 版本更新记录（v1.8.67、v1.8.68、v1.8.69）
- background.js - 添加右键菜单初始化标志（v1.8.67）；重构 contextMenus 创建逻辑（async/await），右键菜单统一使用英文，去除 i18n 化（v1.8.68）；修复 `tabs.onUpdated` 的 URL 过滤条件 Bug（v1.8.68）；简化URL检查条件（v1.8.68）；重构了初始化和事件处理逻辑（v1.8.69）
- shared-i18n-base.js - 优化翻译加载机制，避免重复加载脚本文件，完善翻译回退（v1.8.68）
- I18n_Usage_Guide.md - 内容更新（v1.8.67、v1.8.68）
- .gitignore - git忽略文件更新（v1.8.67）
- Problems.md - 问题列表更新（v1.8.68、v1.8.69）
- Wiki.md - Wiki更新（v1.8.69）

### 移除内容

- 移除未使用的变量 chrome.runtime.lastError 读取语句
- 已完成的TODO / 已修复的问题
- 将 `performInitialization` 和 `handleAutoSwitchToggleRequest` 中的重复规则应用逻辑提取到新的共享函数 `applyLanguageRulesBasedOnState` 中